### PR TITLE
feat(nice-grpc): support `ts-proto` service definitions

### DIFF
--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -142,6 +142,22 @@ const exampleServiceImpl: ServiceImplementation<
 };
 ```
 
+Alternatively, you can use classes:
+
+```ts
+class ExampleServiceImpl
+  implements ServiceImplementation<typeof ExampleServiceDefinition>
+{
+  async exampleUnaryMethod(
+    request: ExampleRequest,
+  ): Promise<DeepPartial<ExampleResponse>> {
+    // ... method logic
+
+    return response;
+  }
+}
+```
+
 With `ts-proto`, response is automatically wrapped with `fromPartial`.
 
 When compiling Protobufs using `google-protobuf`:
@@ -161,22 +177,6 @@ const exampleServiceImpl: ServiceImplementation<IExampleService> = {
 ```
 
 Further examples use `ts-proto`.
-
-Alternatively, you can use classes:
-
-```ts
-class ExampleServiceImpl
-  implements ServiceImplementation<typeof ExampleServiceDefinition>
-{
-  async exampleUnaryMethod(
-    request: ExampleRequest,
-  ): Promise<DeepPartial<ExampleResponse>> {
-    // ... method logic
-
-    return response;
-  }
-}
-```
 
 Now we can create and start a server that exposes our service:
 

--- a/packages/nice-grpc/fixtures/test.proto
+++ b/packages/nice-grpc/fixtures/test.proto
@@ -10,7 +10,9 @@ service Test {
 }
 
 service Test2 {
-  rpc TestUnary(TestRequest) returns(TestResponse){};
+  rpc TestUnary(TestRequest) returns(TestResponse){
+    option idempotency_level = IDEMPOTENT;
+  };
 }
 
 message TestRequest {

--- a/packages/nice-grpc/jest.config.js
+++ b/packages/nice-grpc/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
-  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/src/__tests__/utils/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/lib/',
+    '/src/__tests__/utils/',
+    '/fixtures/',
+  ],
   snapshotSerializers: ['./src/__tests__/utils/snapshotSerializer'],
   preset: 'ts-jest',
   testEnvironment: 'node',

--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -21,7 +21,9 @@
     "test": "jest",
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
-    "prepare:proto": "grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures --ts_out=grpc_js:./fixtures --grpc_out=grpc_js:./fixtures -I fixtures fixtures/*.proto",
+    "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
+    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "prepare:proto": "npm run prepare:proto:grpc-js && npm run prepare:proto:ts-proto",
     "prepare": "npm run prepare:proto"
   },
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
@@ -36,7 +38,9 @@
     "google-protobuf": "^3.14.0",
     "grpc-tools": "^1.10.0",
     "grpc_tools_node_protoc_ts": "^5.0.1",
-    "rimraf": "^2.6.3"
+    "mkdirp": "^1.0.4",
+    "rimraf": "^2.6.3",
+    "ts-proto": "^1.82.0"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.2.6",

--- a/packages/nice-grpc/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/bidiStreaming.ts
@@ -10,8 +10,8 @@ import {
   ServerError,
   Status,
 } from '..';
-import {TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 
 test('basic', async () => {

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/bidiStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/bidiStreaming.ts
@@ -7,8 +7,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestClientMiddleware} from '../utils/testClientMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/chain.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/chain.ts
@@ -1,7 +1,7 @@
 import getPort = require('get-port');
 import {createChannel, createClientFactory, createServer} from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestClientMiddleware} from '../utils/testClientMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/clientStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/clientStreaming.ts
@@ -7,8 +7,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestClientMiddleware} from '../utils/testClientMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/serverStreaming.ts
@@ -7,8 +7,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestClientMiddleware} from '../utils/testClientMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/unary.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/unary.ts
@@ -7,8 +7,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestClientMiddleware} from '../utils/testClientMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/clientStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientStreaming.ts
@@ -10,8 +10,8 @@ import {
   ServerError,
   Status,
 } from '..';
-import {TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 
 test('basic', async () => {

--- a/packages/nice-grpc/src/__tests__/defaultCallOptions.ts
+++ b/packages/nice-grpc/src/__tests__/defaultCallOptions.ts
@@ -1,8 +1,8 @@
 import getPort = require('get-port');
 import {Channel} from '@grpc/grpc-js';
 import {createChannel, createClient, createServer, Metadata, Server} from '..';
-import {TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 
 let server: Server;

--- a/packages/nice-grpc/src/__tests__/serverClass.ts
+++ b/packages/nice-grpc/src/__tests__/serverClass.ts
@@ -7,8 +7,8 @@ import {
   ServiceImplementation,
   Status,
 } from '..';
-import {ITestService, TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {ITestService, TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 
 test('server class', async () => {
   const server = createServer();

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/bidiStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/bidiStreaming.ts
@@ -6,8 +6,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/chain.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/chain.ts
@@ -1,7 +1,7 @@
 import getPort = require('get-port');
 import {createChannel, createClient, createServer} from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/clientStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/clientStreaming.ts
@@ -6,8 +6,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/perService.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/perService.ts
@@ -1,7 +1,7 @@
 import getPort = require('get-port');
 import {createChannel, createClient, createServer} from '../..';
-import {Test2Service, TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {Test2Service, TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/serverStreaming.ts
@@ -6,8 +6,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverMiddleware/unary.ts
+++ b/packages/nice-grpc/src/__tests__/serverMiddleware/unary.ts
@@ -6,8 +6,8 @@ import {
   ServerError,
   Status,
 } from '../..';
-import {TestService} from '../../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../../fixtures/test_pb';
+import {TestService} from '../../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../../fixtures/grpc-js/test_pb';
 import {createTestServerMiddleware} from '../utils/testServerMiddleware';
 import {throwUnimplemented} from '../utils/throwUnimplemented';
 

--- a/packages/nice-grpc/src/__tests__/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverStreaming.ts
@@ -10,8 +10,8 @@ import {
   ServerError,
   Status,
 } from '..';
-import {TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 
 test('basic', async () => {

--- a/packages/nice-grpc/src/__tests__/ts-proto.ts
+++ b/packages/nice-grpc/src/__tests__/ts-proto.ts
@@ -1,0 +1,41 @@
+import getPort = require('get-port');
+import {createChannel, createClient, createServer} from '..';
+import {
+  DeepPartial,
+  TestDefinition,
+  TestRequest,
+  TestResponse,
+} from '../../fixtures/ts-proto/test';
+import {throwUnimplemented} from './utils/throwUnimplemented';
+
+test('basic', async () => {
+  const server = createServer();
+
+  server.add(TestDefinition, {
+    async testUnary(request: TestRequest): Promise<DeepPartial<TestResponse>> {
+      return {
+        id: request.id,
+      };
+    },
+    testServerStream: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const address = `localhost:${await getPort()}`;
+
+  await server.listen(address);
+
+  const channel = createChannel(address);
+  const client = createClient(TestDefinition, channel);
+
+  await expect(client.testUnary({id: 'test'})).resolves.toMatchInlineSnapshot(`
+          Object {
+            "id": "test",
+          }
+        `);
+
+  channel.close();
+
+  await server.shutdown();
+});

--- a/packages/nice-grpc/src/__tests__/ts-proto.ts
+++ b/packages/nice-grpc/src/__tests__/ts-proto.ts
@@ -3,6 +3,7 @@ import {createChannel, createClient, createServer} from '..';
 import {
   DeepPartial,
   TestDefinition,
+  Test2Definition,
   TestRequest,
   TestResponse,
 } from '../../fixtures/ts-proto/test';
@@ -34,6 +35,63 @@ test('basic', async () => {
             "id": "test",
           }
         `);
+
+  channel.close();
+
+  await server.shutdown();
+});
+
+test('middleware', async () => {
+  const server = createServer();
+
+  const middlewareCalls: any[] = [];
+
+  server
+    .with(async function* (call, context) {
+      middlewareCalls.push(call);
+
+      return yield* call.next(call.request, context);
+    })
+    .add(Test2Definition, {
+      async testUnary(
+        request: TestRequest,
+      ): Promise<DeepPartial<TestResponse>> {
+        return {
+          id: request.id,
+        };
+      },
+    });
+
+  const address = `localhost:${await getPort()}`;
+
+  await server.listen(address);
+
+  const channel = createChannel(address);
+  const client = createClient(Test2Definition, channel);
+
+  await expect(client.testUnary({id: 'test'})).resolves.toMatchInlineSnapshot(`
+          Object {
+            "id": "test",
+          }
+        `);
+  expect(middlewareCalls).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "method": Object {
+          "options": Object {
+            "idempotencyLevel": "IDEMPOTENT",
+          },
+          "path": "/nice_grpc.test.Test2/TestUnary",
+        },
+        "next": [Function],
+        "request": Object {
+          "id": "test",
+        },
+        "requestStream": false,
+        "responseStream": false,
+      },
+    ]
+  `);
 
   channel.close();
 

--- a/packages/nice-grpc/src/__tests__/unary.ts
+++ b/packages/nice-grpc/src/__tests__/unary.ts
@@ -10,8 +10,8 @@ import {
   ServerError,
   Status,
 } from '..';
-import {TestService} from '../../fixtures/test_grpc_pb';
-import {TestRequest, TestResponse} from '../../fixtures/test_pb';
+import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
+import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 
 test('basic', async () => {

--- a/packages/nice-grpc/src/service-definitions/index.ts
+++ b/packages/nice-grpc/src/service-definitions/index.ts
@@ -4,6 +4,12 @@ import {
   FromGrpcJsServiceDefinition,
   isGrpcJsServiceDefinition,
 } from './grpc-js';
+import {
+  fromTsProtoServiceDefinition,
+  FromTsProtoServiceDefinition,
+  isTsProtoServiceDefinition,
+  TsProtoServiceDefinition,
+} from './ts-proto';
 
 export type ServiceDefinition = {
   [method: string]: AnyMethodDefinition;
@@ -33,7 +39,8 @@ export type AnyMethodDefinition = MethodDefinition<any, any, any, any>;
 
 export type CompatServiceDefinition =
   | ServiceDefinition
-  | grpc.ServiceDefinition;
+  | grpc.ServiceDefinition
+  | TsProtoServiceDefinition;
 
 export type NormalizedServiceDefinition<
   Service extends CompatServiceDefinition,
@@ -41,6 +48,8 @@ export type NormalizedServiceDefinition<
   ? Service
   : Service extends grpc.ServiceDefinition
   ? FromGrpcJsServiceDefinition<Service>
+  : Service extends TsProtoServiceDefinition
+  ? FromTsProtoServiceDefinition<Service>
   : never;
 
 /** @internal */
@@ -49,6 +58,8 @@ export function normalizeServiceDefinition(
 ): ServiceDefinition {
   if (isGrpcJsServiceDefinition(definition)) {
     return fromGrpcJsServiceDefinition(definition);
+  } else if (isTsProtoServiceDefinition(definition)) {
+    return fromTsProtoServiceDefinition(definition);
   } else {
     return definition;
   }

--- a/packages/nice-grpc/src/service-definitions/ts-proto.ts
+++ b/packages/nice-grpc/src/service-definitions/ts-proto.ts
@@ -1,0 +1,99 @@
+import {CompatServiceDefinition, MethodDefinition, ServiceDefinition} from '.';
+
+export type TsProtoServiceDefinition = {
+  name: string;
+  fullName: string;
+  methods: {
+    [method: string]: TsProtoMethodDefinition<any, any>;
+  };
+};
+
+export type TsProtoMethodDefinition<Request, Response> = {
+  name: string;
+  requestType: TsProtoMessageType<Request>;
+  requestStream: boolean;
+  responseType: TsProtoMessageType<Response>;
+  responseStream: boolean;
+  options: {
+    idempotencyLevel?: 'IDEMPOTENT' | 'NO_SIDE_EFFECTS';
+  };
+};
+
+export type TsProtoMessageType<Message> = {
+  encode(message: Message): ProtobufJsWriter;
+  decode(input: Uint8Array): Message;
+  fromPartial?(object: unknown): Message;
+};
+
+export type ProtobufJsWriter = {
+  finish(): Uint8Array;
+};
+
+export type TsProtoMessageIn<
+  Type extends TsProtoMessageType<any>
+> = Type['fromPartial'] extends Function
+  ? Parameters<Type['fromPartial']>[0]
+  : Type extends TsProtoMessageType<infer Message>
+  ? Message
+  : never;
+
+export type FromTsProtoServiceDefinition<
+  Service extends TsProtoServiceDefinition
+> = {
+  [M in keyof Service['methods']]: FromTsProtoMethodDefinition<
+    Service['methods'][M]
+  >;
+};
+
+export type FromTsProtoMethodDefinition<
+  Method
+> = Method extends TsProtoMethodDefinition<infer Request, infer Response>
+  ? MethodDefinition<
+      TsProtoMessageIn<Method['requestType']>,
+      Request,
+      TsProtoMessageIn<Method['responseType']>,
+      Response,
+      Method['requestStream'],
+      Method['responseStream']
+    >
+  : never;
+
+export function fromTsProtoServiceDefinition(
+  definition: TsProtoServiceDefinition,
+): ServiceDefinition {
+  const result: ServiceDefinition = {};
+
+  for (const [key, method] of Object.entries(definition.methods)) {
+    const requestEncode = method.requestType.encode;
+    const requestFromPartial = method.requestType.fromPartial;
+    const responseEncode = method.responseType.encode;
+    const responseFromPartial = method.responseType.fromPartial;
+
+    result[key] = {
+      path: `/${definition.fullName}/${method.name}`,
+      requestStream: method.requestStream,
+      responseStream: method.responseStream,
+      requestDeserialize: method.requestType.decode,
+      requestSerialize:
+        requestFromPartial != null
+          ? value => requestEncode(requestFromPartial(value)).finish()
+          : value => requestEncode(value).finish(),
+      responseDeserialize: method.responseType.decode,
+      responseSerialize:
+        responseFromPartial != null
+          ? value => responseEncode(responseFromPartial(value)).finish()
+          : value => responseEncode(value).finish(),
+      options: method.options,
+    };
+  }
+
+  return result;
+}
+
+export function isTsProtoServiceDefinition(
+  definition: CompatServiceDefinition,
+): definition is TsProtoServiceDefinition {
+  return (
+    'name' in definition && 'fullName' in definition && 'methods' in definition
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,6 +1383,59 @@
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1496,6 +1549,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/minimatch@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
@@ -1511,6 +1569,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
   integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
 
+"@types/node@>=13.7.0":
+  version "15.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
+  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
+
 "@types/node@^13.7.4":
   version "13.13.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
@@ -1521,10 +1584,20 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/object-hash@^1.3.0":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.4.tgz#079ba142be65833293673254831b5e3e847fe58b"
+  integrity sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/prettier@^1.19.0":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
+  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
 "@types/prettier@^2.1.5":
   version "2.3.0"
@@ -2411,6 +2484,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -4336,6 +4414,11 @@ lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -4902,6 +4985,11 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
 object-inspect@^1.10.3, object-inspect@^1.9.0:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
@@ -5276,6 +5364,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.0.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
 prettier@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
@@ -5338,6 +5431,25 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protobufjs@^6.8.8:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
@@ -6259,6 +6371,35 @@ ts-jest@^27.0.3:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-poet@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-4.5.0.tgz#bb07ffe379d5a96f5e81da72a00edad45b28e9ca"
+  integrity sha512-Vs2Zsiz3zf5qdFulFTIEpaLdgWeHXKh+4pv+ycVqEh+ZuUOVGrN0i9lbxVx7DB1FBogExytz3OuaBMJfWffpSQ==
+  dependencies:
+    "@types/prettier" "^1.19.0"
+    lodash "^4.17.15"
+    prettier "^2.0.2"
+
+ts-proto-descriptors@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.3.1.tgz#760ebaaa19475b03662f7b358ffea45b9c5348f5"
+  integrity sha512-Cybb3fqceMwA6JzHdC32dIo8eVGVmXrM6TWhdk1XQVVHT/6OQqk0ioyX1dIdu3rCIBhRmWUhUE4HsyK+olmgMw==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.8.8"
+
+ts-proto@^1.82.0:
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.82.0.tgz#9637dafd59f291f4cca8d507fc24ba490e0703ee"
+  integrity sha512-vo4QN4QhR0D4/+C/pSbRIVSV6U7dooNcuyW3SL9DvhKRQA4lnAbF5QBs77ge3JRi+aSZJm8MlzTNk7+e++fvvQ==
+  dependencies:
+    "@types/object-hash" "^1.3.0"
+    dataloader "^1.4.0"
+    object-hash "^1.3.1"
+    protobufjs "^6.8.8"
+    ts-poet "^4.5.0"
+    ts-proto-descriptors "^1.2.1"
 
 ts-protoc-gen@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
You can now use `ts-proto` with `outputServices=generic-definitions`.

- Requests on the client and responses on the server are automatically wrapped with `fromPartial`.
- Method options like `idempotency_level` are preserved and are visible in middleware.