### PR TITLE
fix: check availability of Error.captureStackTrace before using it

### DIFF
--- a/packages/nice-grpc-common/src/client/ClientError.ts
+++ b/packages/nice-grpc-common/src/client/ClientError.ts
@@ -13,7 +13,9 @@ export class ClientError extends Error {
       value: true,
     });
 
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 
   static [Symbol.hasInstance](instance: unknown) {

--- a/packages/nice-grpc-common/src/server/ServerError.ts
+++ b/packages/nice-grpc-common/src/server/ServerError.ts
@@ -9,7 +9,9 @@ export class ServerError extends Error {
       value: true,
     });
 
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 
   static [Symbol.hasInstance](instance: unknown) {


### PR DESCRIPTION
`Error.captureStackTrace` is not available in Firefox, leading to the following error:
```
TypeError: Error.captureStackTrace is not a function
```
Similar issues can be found in other projects (https://github.com/trentm/node-bunyan/issues/224).
I'm only capturing the stack if the function is available. Let me know if that behavior suits you.
The stack trace still looks good without.
And no need to change in `*.test.ts` as the function is always available in node env.