### PR TITLE
chore: fix compatibility with `ts-proto`

### DIFF
--- a/packages/nice-grpc-client-middleware-retry/package.json
+++ b/packages/nice-grpc-client-middleware-retry/package.json
@@ -16,7 +16,7 @@
     "test": "jest",
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
-    "build:proto": "grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "build:proto": "grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare": "npm run build:proto"
   },
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
@@ -26,7 +26,7 @@
     "grpc-tools": "^1.10.0",
     "jest-mock-random": "^1.1.1",
     "nice-grpc": "^1.0.4",
-    "ts-proto": "^1.82.5"
+    "ts-proto": "^1.97.0"
   },
   "dependencies": {
     "abort-controller-x": "^0.2.6",

--- a/packages/nice-grpc-server-health/package.json
+++ b/packages/nice-grpc-server-health/package.json
@@ -17,7 +17,7 @@
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
     "prepare:grpc-health-probe": "path-exists grpc-health-probe || node scripts/download_grpc_health_probe.js",
-    "prepare:proto": "mkdirp ./src/proto && grpc_tools_node_protoc --ts_proto_out=./src/proto --ts_proto_opt=outputJsonMethods=false,outputPartialMethods=false,outputServices=generic-definitions -I ./proto proto/grpc/health/v1/health.proto",
+    "prepare:proto": "mkdirp ./src/proto && grpc_tools_node_protoc --ts_proto_out=./src/proto --ts_proto_opt=outputJsonMethods=false,outputPartialMethods=false,outputServices=generic-definitions,useExactTypes=false -I ./proto proto/grpc/health/v1/health.proto",
     "prepare": "npm run prepare:grpc-health-probe && npm run prepare:proto"
   },
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
@@ -31,7 +31,7 @@
     "nice-grpc-server-middleware-terminator": "^1.0.1",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",
-    "ts-proto": "^1.82.0"
+    "ts-proto": "^1.97.0"
   },
   "dependencies": {
     "abort-controller-x": "^0.2.6",

--- a/packages/nice-grpc-server-middleware-terminator/package.json
+++ b/packages/nice-grpc-server-middleware-terminator/package.json
@@ -16,7 +16,7 @@
     "test": "jest",
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
-    "build:proto": "grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "build:proto": "grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare": "npm run build:proto"
   },
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
@@ -28,7 +28,7 @@
     "defer-promise": "^2.0.1",
     "grpc-tools": "^1.10.0",
     "nice-grpc": "^1.0.4",
-    "ts-proto": "^1.82.0"
+    "ts-proto": "^1.97.0"
   },
   "dependencies": {
     "nice-grpc-common": "^1.0.3",

--- a/packages/nice-grpc-web/README.md
+++ b/packages/nice-grpc-web/README.md
@@ -58,7 +58,7 @@ directory `./compiled_proto`:
 ./node_modules/.bin/grpc_tools_node_protoc \
   --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto \
   --ts_proto_out=./compiled_proto \
-  --ts_proto_opt=env=browser,outputServices=generic-definitions,outputJsonMethods=false \
+  --ts_proto_opt=env=browser,outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false \
   --proto_path=./proto \
   ./proto/example.proto
 ```

--- a/packages/nice-grpc-web/package.json
+++ b/packages/nice-grpc-web/package.json
@@ -27,7 +27,7 @@
     "prepare:grpcwebproxy": "path-exists grpcwebproxy || node scripts/download_grpcwebproxy.js",
     "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=../../node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
     "prepare:proto:grpc-web": "mkdirp ./fixtures/grpc-web && grpc_tools_node_protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-web --ts_out=service=grpc-web:./fixtures/grpc-web -I fixtures fixtures/*.proto",
-    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,outputJsonMethods=false,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare:proto": "npm run prepare:proto:grpc-js && npm run prepare:proto:grpc-web && npm run prepare:proto:ts-proto",
     "prepare": "npm run prepare:grpcwebproxy && npm run prepare:proto"
   },
@@ -45,7 +45,7 @@
     "path-exists-cli": "^1.0.0",
     "request": "^2.88.2",
     "tcp-port-used": "^1.0.2",
-    "ts-proto": "^1.82.0",
+    "ts-proto": "^1.97.0",
     "ts-protoc-gen": "^0.15.0",
     "unzipper": "^0.10.11",
     "ws": "^7.5.0"

--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -71,7 +71,7 @@ directory `./compiled_proto`:
 ./node_modules/.bin/grpc_tools_node_protoc \
   --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto \
   --ts_proto_out=./compiled_proto \
-  --ts_proto_opt=outputServices=generic-definitions \
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
   --proto_path=./proto \
   ./proto/example.proto
 ```

--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -25,7 +25,7 @@
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
     "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
-    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare:proto": "npm run prepare:proto:grpc-js && npm run prepare:proto:ts-proto",
     "prepare": "npm run prepare:proto"
   },
@@ -43,7 +43,7 @@
     "grpc_tools_node_protoc_ts": "^5.0.1",
     "mkdirp": "^1.0.4",
     "rimraf": "^2.6.3",
-    "ts-proto": "^1.82.0"
+    "ts-proto": "^1.97.0"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6401,10 +6401,10 @@ ts-proto-descriptors@^1.2.1:
     long "^4.0.0"
     protobufjs "^6.8.8"
 
-ts-proto@^1.82.0, ts-proto@^1.82.5:
-  version "1.82.5"
-  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.82.5.tgz#9dd11785e314e2ae5467c09acdb739de010487b7"
-  integrity sha512-RqlTxosROuYdeWRLa6Qu8Wz9dc3fpAh+R8PELUlhSSZlUiEkTos662SgKHOB8UoJd9CBMSyJPRC7z8k2WvWzhw==
+ts-proto@^1.97.0:
+  version "1.97.0"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.97.0.tgz#df302eb7df48859df25325a614d2e871318ad21c"
+  integrity sha512-GrECiLTy5POpIZehd7r8lsnrBz1QqG9Sfr3x4ytbz7YRjSjMZeBIG3LI2gW0KtIL1VrUTJic3wV61PR5i7AaQQ==
   dependencies:
     "@types/object-hash" "^1.3.0"
     dataloader "^1.4.0"


### PR DESCRIPTION
Updated `ts-proto` compilations to use `ts-proto@1.97.0` with an option `useExactTypes=false`.

Closes #26