### PR TITLE
fix(nice-grpc-common): fix issues with `ServerError` and `ClientError` when transpiling to older environments

### DIFF
--- a/packages/nice-grpc-common/package.json
+++ b/packages/nice-grpc-common/package.json
@@ -23,6 +23,7 @@
     "@tsconfig/recommended": "^1.0.1"
   },
   "dependencies": {
-    "node-abort-controller": "^2.0.0"
+    "node-abort-controller": "^2.0.0",
+    "ts-error": "^1.0.6"
   }
 }

--- a/packages/nice-grpc-common/src/client/ClientError.ts
+++ b/packages/nice-grpc-common/src/client/ClientError.ts
@@ -1,9 +1,10 @@
+import ExtendableError from 'ts-error';
 import {Status} from '../Status';
 
 /**
  * Represents gRPC errors returned from client calls.
  */
-export class ClientError extends Error {
+export class ClientError extends ExtendableError {
   /**
    * Path of the client call.
    *
@@ -22,8 +23,6 @@ export class ClientError extends Error {
   constructor(path: string, code: Status, details: string) {
     super(`${path} ${Status[code]}: ${details}`);
 
-    Object.setPrototypeOf(this, ClientError.prototype);
-
     this.path = path;
     this.code = code;
     this.details = details;
@@ -32,10 +31,6 @@ export class ClientError extends Error {
     Object.defineProperty(this, '@@nice-grpc', {
       value: true,
     });
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
   }
 
   static [Symbol.hasInstance](instance: unknown) {

--- a/packages/nice-grpc-common/src/server/ServerError.ts
+++ b/packages/nice-grpc-common/src/server/ServerError.ts
@@ -1,10 +1,11 @@
+import ExtendableError from 'ts-error';
 import {Status} from '../Status';
 
 /**
  * Service implementations may throw this error to report gRPC errors to
  * clients.
  */
-export class ServerError extends Error {
+export class ServerError extends ExtendableError {
   /**
    * Status code to report to the client.
    */
@@ -17,8 +18,6 @@ export class ServerError extends Error {
   constructor(code: Status, details: string) {
     super(`${Status[code]}: ${details}`);
 
-    Object.setPrototypeOf(this, ServerError.prototype);
-
     this.code = code;
     this.details = details;
 
@@ -26,10 +25,6 @@ export class ServerError extends Error {
     Object.defineProperty(this, '@@nice-grpc', {
       value: true,
     });
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
   }
 
   static [Symbol.hasInstance](instance: unknown) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6730,6 +6730,11 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz#8df24847fcb821b0ab27d58ab6efec9f2fe961a1"
   integrity sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==
 
+ts-error@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/ts-error/-/ts-error-1.0.6.tgz#277496f2a28de6c184cfce8dfd5cdd03a4e6b0fc"
+  integrity sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==
+
 ts-jest@^27.0.3:
   version "27.1.3"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"


### PR DESCRIPTION
Use [ts-error](https://www.npmjs.com/package/ts-error) for custom errors.