### PR TITLE
feat: add support for `ts-proto` server and client interfaces

### DIFF
--- a/packages/nice-grpc-client-middleware-retry/package.json
+++ b/packages/nice-grpc-client-middleware-retry/package.json
@@ -26,7 +26,7 @@
     "grpc-tools": "^1.10.0",
     "jest-mock-random": "^1.1.1",
     "nice-grpc": "^1.1.1",
-    "ts-proto": "^1.97.0"
+    "ts-proto": "^1.112.0"
   },
   "dependencies": {
     "abort-controller-x": "^0.2.6",

--- a/packages/nice-grpc-error-details/package.json
+++ b/packages/nice-grpc-error-details/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "nice-grpc": "^1.1.1",
     "rimraf": "^3.0.2",
-    "ts-proto": "^1.97.0"
+    "ts-proto": "^1.112.0"
   },
   "dependencies": {
     "nice-grpc-common": "^1.1.0",

--- a/packages/nice-grpc-server-health/package.json
+++ b/packages/nice-grpc-server-health/package.json
@@ -31,7 +31,7 @@
     "nice-grpc-server-middleware-terminator": "^1.0.7",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",
-    "ts-proto": "^1.97.0"
+    "ts-proto": "^1.112.0"
   },
   "dependencies": {
     "abort-controller-x": "^0.2.6",

--- a/packages/nice-grpc-server-middleware-terminator/package.json
+++ b/packages/nice-grpc-server-middleware-terminator/package.json
@@ -28,7 +28,7 @@
     "defer-promise": "^2.0.1",
     "grpc-tools": "^1.10.0",
     "nice-grpc": "^1.1.1",
-    "ts-proto": "^1.97.0"
+    "ts-proto": "^1.112.0"
   },
   "dependencies": {
     "nice-grpc-common": "^1.1.0",

--- a/packages/nice-grpc-web/README.md
+++ b/packages/nice-grpc-web/README.md
@@ -51,6 +51,8 @@ npm install protobufjs long
 npm install --save-dev grpc-tools ts-proto
 ```
 
+> Use `ts-proto` version not older than `1.112.0`.
+
 Given a Protobuf file `./proto/example.proto`, generate TypeScript code into
 directory `./compiled_proto`:
 
@@ -58,7 +60,7 @@ directory `./compiled_proto`:
 ./node_modules/.bin/grpc_tools_node_protoc \
   --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto \
   --ts_proto_out=./compiled_proto \
-  --ts_proto_opt=env=browser,outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false \
+  --ts_proto_opt=env=browser,outputServices=nice-grpc,outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false \
   --proto_path=./proto \
   ./proto/example.proto
 ```
@@ -130,11 +132,14 @@ When compiling Protobufs using `ts-proto`:
 
 ```ts
 import {createChannel, createClient} from 'nice-grpc-web';
-import {ExampleServiceDefinition} from './compiled_proto/example';
+import {
+  ExampleServiceClient,
+  ExampleServiceDefinition,
+} from './compiled_proto/example';
 
 const channel = createChannel('http://localhost:8080');
 
-const client: Client<typeof ExampleServiceDefinition> = createClient(
+const client: ExampleServiceClient = createClient(
   ExampleServiceDefinition,
   channel,
 );

--- a/packages/nice-grpc-web/package.json
+++ b/packages/nice-grpc-web/package.json
@@ -27,7 +27,7 @@
     "prepare:grpcwebproxy": "path-exists grpcwebproxy || node scripts/download_grpcwebproxy.js",
     "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=../../node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
     "prepare:proto:grpc-web": "mkdirp ./fixtures/grpc-web && grpc_tools_node_protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-web --ts_out=service=grpc-web:./fixtures/grpc-web -I fixtures fixtures/*.proto",
-    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare:proto": "npm run prepare:proto:grpc-js && npm run prepare:proto:grpc-web && npm run prepare:proto:ts-proto",
     "prepare": "npm run prepare:grpcwebproxy && npm run prepare:proto"
   },
@@ -45,7 +45,7 @@
     "path-exists-cli": "^2.0.0",
     "request": "^2.88.2",
     "tcp-port-used": "^1.0.2",
-    "ts-proto": "^1.97.0",
+    "ts-proto": "^1.112.0",
     "ts-protoc-gen": "^0.15.0",
     "unzipper": "^0.10.11",
     "ws": "^8.4.2"

--- a/packages/nice-grpc-web/src/__tests__/ts-proto.ts
+++ b/packages/nice-grpc-web/src/__tests__/ts-proto.ts
@@ -3,6 +3,7 @@ import {createServer} from 'nice-grpc';
 import {createChannel, createClient} from '..';
 import {
   DeepPartial,
+  TestClient,
   TestDefinition,
   TestRequest,
   TestResponse,
@@ -36,7 +37,7 @@ test('basic', async () => {
     `http://localhost:${proxyPort}`,
     WebsocketTransport(),
   );
-  const client = createClient(TestDefinition, channel);
+  const client: TestClient = createClient(TestDefinition, channel);
 
   await expect(client.testUnary({id: 'test'})).resolves.toMatchInlineSnapshot(`
           Object {

--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -64,6 +64,8 @@ npm install protobufjs long
 npm install --save-dev grpc-tools ts-proto
 ```
 
+> Use `ts-proto` version not older than `1.112.0`.
+
 Given a Protobuf file `./proto/example.proto`, generate TypeScript code into
 directory `./compiled_proto`:
 
@@ -71,7 +73,7 @@ directory `./compiled_proto`:
 ./node_modules/.bin/grpc_tools_node_protoc \
   --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto \
   --ts_proto_out=./compiled_proto \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,useExactTypes=false \
   --proto_path=./proto \
   ./proto/example.proto
 ```
@@ -128,17 +130,14 @@ After compiling Protobuf file, we can write service implementation:
 When compiling Protobufs using `ts-proto`:
 
 ```ts
-import {ServiceImplementation} from 'nice-grpc';
 import {
-  ExampleServiceDefinition,
+  ExampleServiceImplementation,
   ExampleRequest,
   ExampleResponse,
   DeepPartial,
 } from './compiled_proto/example';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async exampleUnaryMethod(
     request: ExampleRequest,
   ): Promise<DeepPartial<ExampleResponse>> {
@@ -152,9 +151,7 @@ const exampleServiceImpl: ServiceImplementation<
 Alternatively, you can use classes:
 
 ```ts
-class ExampleServiceImpl
-  implements ServiceImplementation<typeof ExampleServiceDefinition>
-{
+class ExampleServiceImpl implements ExampleServiceImplementation {
   async exampleUnaryMethod(
     request: ExampleRequest,
   ): Promise<DeepPartial<ExampleResponse>> {
@@ -255,9 +252,7 @@ the correct usage of status codes.
 ```ts
 import {ServerError, Status} from 'nice-grpc';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async exampleUnaryMethod(
     request: ExampleRequest,
   ): Promise<DeepPartial<ExampleResponse>> {
@@ -274,9 +269,7 @@ A server receives client metadata along with request, and can send response
 metadata in header and trailer.
 
 ```ts
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async exampleUnaryMethod(
     request: ExampleRequest,
     context: CallContext,
@@ -307,9 +300,7 @@ cancel any inner requests.
 ```ts
 import fetch from 'node-fetch';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async exampleUnaryMethod(
     request: ExampleRequest,
     context: CallContext,
@@ -339,9 +330,7 @@ Service implementation defines this method as an Async Generator:
 ```ts
 import {delay} from 'abort-controller-x';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async *exampleStreamingMethod(
     request: ExampleRequest,
     context: CallContext,
@@ -361,9 +350,7 @@ const exampleServiceImpl: ServiceImplementation<
 import {range} from 'ix/asynciterable';
 import {withAbort, map} from 'ix/asynciterable/operators';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async *exampleStreamingMethod(
     request: ExampleRequest,
     context: CallContext,
@@ -383,9 +370,7 @@ import {Observable} from 'rxjs';
 import {from} from 'ix/asynciterable';
 import {withAbort} from 'ix/asynciterable/operators';
 
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async *exampleStreamingMethod(
     request: ExampleRequest,
     context: CallContext,
@@ -411,9 +396,7 @@ service ExampleService {
 Service implementation method receives request as an Async Iterable:
 
 ```ts
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition
-> = {
+const exampleServiceImpl: ExampleServiceImplementation = {
   async exampleUnaryMethod(
     request: AsyncIterable<ExampleRequest>,
   ): Promise<DeepPartial<ExampleResponse>> {
@@ -628,10 +611,7 @@ async function* authMiddleware<Request, Response>(
 Service implementation can then access JWT claims via call context:
 
 ```ts
-const exampleServiceImpl: ServiceImplementation<
-  typeof ExampleServiceDefinition,
-  AuthCallContextExt
-> = {
+const exampleServiceImpl: ExampleServiceImplementation<AuthCallContextExt> = {
   async exampleUnaryMethod(
     request: ExampleRequest,
     context: CallContext & AuthCallContextExt,
@@ -669,12 +649,15 @@ After compiling Protobuf file, we can create the client:
 When compiling Protobufs using `ts-proto`:
 
 ```ts
-import {createChannel, createClient, Client} from 'nice-grpc';
-import {ExampleServiceDefinition} from './compiled_proto/example';
+import {createChannel, createClient} from 'nice-grpc';
+import {
+  ExampleServiceClient,
+  ExampleServiceDefinition,
+} from './compiled_proto/example';
 
 const channel = createChannel('localhost:8080');
 
-const client: Client<typeof ExampleServiceDefinition> = createClient(
+const client: ExampleServiceClient = createClient(
   ExampleServiceDefinition,
   channel,
 );

--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -25,7 +25,7 @@
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
     "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
-    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
+    "prepare:proto:ts-proto": "mkdirp ./fixtures/ts-proto && grpc_tools_node_protoc --ts_proto_out=./fixtures/ts-proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto",
     "prepare:proto": "npm run prepare:proto:grpc-js && npm run prepare:proto:ts-proto",
     "prepare": "npm run prepare:proto"
   },
@@ -43,7 +43,7 @@
     "grpc_tools_node_protoc_ts": "^5.0.1",
     "mkdirp": "^1.0.4",
     "rimraf": "^2.6.3",
-    "ts-proto": "^1.97.0"
+    "ts-proto": "^1.112.0"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6737,10 +6737,10 @@ ts-proto-descriptors@1.6.0:
     long "^4.0.0"
     protobufjs "^6.8.8"
 
-ts-proto@^1.97.0:
-  version "1.110.4"
-  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.110.4.tgz#59f0a7fff17103babec73cfb53eee4ef68ecb76f"
-  integrity sha512-conMr8adLW8nnnacTyU6aAuAz+TOGjjXc56V5J9J8eeTXzl18R0+85oZ8CVx4Kf6/cHLALgGKmeHhPPIOrwy6Q==
+ts-proto@^1.112.0:
+  version "1.112.0"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.112.0.tgz#25a58893fbdd115aed9a853d60b0bd6b30879a28"
+  integrity sha512-K3TMDxkQ4kYhminDDfxv7W0y9+4a1tAFRnM4SIwlw81EXYKs+ee81i+18xOc8MclpYpO3xzweFor4zYAAq05fg==
   dependencies:
     "@types/object-hash" "^1.3.0"
     dataloader "^1.4.0"


### PR DESCRIPTION
Starting from version `1.112.0` [`ts-proto`](https://github.com/stephenh/ts-proto) is able to generate TypeScript interfaces for `nice-grpc` service implementations and clients. So instead of `ServiceImplementation<typeof YourServiceDefinition>` you can write `YourServiceImplementation` and instead of `Client<typeof YourServiceDefinition>` just use `YourServiceClient`. This will also make IDE hints more developer-friendly.

To start using this feature, add `outputServices=nice-grpc` to `ts_proto_opt`. Note that `outputServices=nice-grpc` is still required, i.e. you should include `outputServices` option twice. For complete examples see the docs on compiling Protobuf files for [`nice-grpc`](https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc/README.md#using-ts-proto) and [`nice-grpc-web`](https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc-web/README.md#using-ts-proto).

Closes #115