### PR TITLE
fix(channel): no longer reject invalid protocols

### DIFF
--- a/packages/nice-grpc/src/__tests__/channel.ts
+++ b/packages/nice-grpc/src/__tests__/channel.ts
@@ -1,6 +1,6 @@
 import getPort = require('get-port');
-import {randomBytes} from 'crypto'
-import {createChannel, createServer, waitForChannelReady} from '..';
+import {randomBytes} from 'crypto';
+import {createChannel, createServer, waitForChannelReady, Channel} from '..';
 
 test('implicit protocol', async () => {
   const address = `localhost:${await getPort()}`;
@@ -42,12 +42,12 @@ test('default port', async () => {
   secureChannel.close();
 });
 
-test('invalid protocol', () => {
-  expect(() =>
-    createChannel('htttp://localhost:123'),
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"Unsupported protocol: 'htttp'. Expected one of 'http', 'https'"`,
-  );
+test('unknown protocol', () => {
+  const address = 'consul://server';
+  const channel = createChannel(address);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}"`);
 });
 
 test('waitForChannelReady deadline', async () => {

--- a/packages/nice-grpc/src/client/channel.ts
+++ b/packages/nice-grpc/src/client/channel.ts
@@ -24,9 +24,9 @@ export function createChannel(
   } else if (protocol === 'https') {
     credentials ??= ChannelCredentials.createSsl();
   } else {
-    throw new Error(
-      `Unsupported protocol: '${protocol}'. Expected one of 'http', 'https'`,
-    );
+    credentials ??= ChannelCredentials.createInsecure();
+
+    return new Channel(address, credentials, options);
   }
 
   return new Channel(`${host}:${port}`, credentials, options);


### PR DESCRIPTION
Instead, pass these unknown addresses directly through to the Channel constructor

Closes #167

_I'm sorry in advance if tests don't pass on the first try. I have an M1 and this project doesn't want to build no matter how hard I try_ 