### PR TITLE
fix: throw `ClientError` with status `CANCELLED` to client middleware on iteration abort

### DIFF
--- a/packages/nice-grpc-web/src/__tests__/clientMiddleware/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/clientMiddleware/bidiStreaming.ts
@@ -205,3 +205,97 @@ test('error', async () => {
   proxy.stop();
   await server.shutdown();
 });
+
+test('aborted iteration on client', async () => {
+  const actions: any[] = [];
+
+  const server = createServer();
+
+  server.add(TestService, {
+    testUnary: throwUnimplemented,
+    testServerStream: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    async *testBidiStream(request: AsyncIterable<TestRequest>) {
+      for await (const req of request) {
+        yield new TestResponse().setId(req.getId());
+      }
+    },
+  });
+
+  const address = `localhost:${await getPort()}`;
+
+  await server.listen(address);
+
+  const proxyPort = await getPort();
+  const proxy = await startProxy(proxyPort, address);
+
+  const channel = createChannel(
+    `http://localhost:${proxyPort}`,
+    WebsocketTransport(),
+  );
+
+  const client = createClientFactory()
+    .use(createTestClientMiddleware('testOption', actions))
+    .create(Test, channel);
+
+  async function* createRequest() {
+    yield new TestRequest().setId('test-1');
+    yield new TestRequest().setId('test-2');
+  }
+
+  const responses: any[] = [];
+
+  for await (const response of client.testBidiStream(createRequest(), {
+    testOption: 'test-value',
+  })) {
+    responses.push(response);
+
+    break;
+  }
+
+  expect(responses).toMatchInlineSnapshot(`
+    Array [
+      nice_grpc.test.TestResponse {
+        "id": "test-1",
+      },
+    ]
+  `);
+
+  expect(actions).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "options": Object {
+          "testOption": "test-value",
+        },
+        "requestStream": true,
+        "responseStream": true,
+        "type": "start",
+      },
+      Object {
+        "request": nice_grpc.test.TestRequest {
+          "id": "test-1",
+        },
+        "type": "request",
+      },
+      Object {
+        "request": nice_grpc.test.TestRequest {
+          "id": "test-2",
+        },
+        "type": "request",
+      },
+      Object {
+        "response": nice_grpc.test.TestResponse {
+          "id": "test-1",
+        },
+        "type": "response",
+      },
+      Object {
+        "error": [ClientError: /nice_grpc.test.Test/TestBidiStream CANCELLED: Stream iteration was aborted by client],
+        "type": "error",
+      },
+    ]
+  `);
+
+  proxy.stop();
+  await server.shutdown();
+});

--- a/packages/nice-grpc-web/src/client/createServerStreamingMethod.ts
+++ b/packages/nice-grpc-web/src/client/createServerStreamingMethod.ts
@@ -139,8 +139,26 @@ export function createServerStreamingMethod<Request, Response>(
 
             return result;
           },
-          return() {
-            return iterator.return();
+          async return() {
+            // if the iteration was aborted by `break` or `return` or `throw`
+            // inside the for .. of loop, let the middleware know by throwing
+            // an error to the generator
+
+            const error = new ClientError(
+              definition.path,
+              Status.CANCELLED,
+              'Stream iteration was aborted by client',
+            );
+
+            try {
+              return await iterator.throw(error);
+            } catch (err) {
+              if (err === error) {
+                return {done: true, value: undefined};
+              }
+
+              throw err;
+            }
           },
           throw(err) {
             return iterator.throw(err);

--- a/packages/nice-grpc/src/__tests__/clientMiddleware/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientMiddleware/serverStreaming.ts
@@ -189,3 +189,82 @@ test('error', async () => {
 
   await server.shutdown();
 });
+
+test('aborted iteration on client', async () => {
+  const actions: any[] = [];
+  
+  const server = createServer();
+
+  server.add(TestService, {
+    testUnary: throwUnimplemented,
+    async *testServerStream(request: TestRequest) {
+      yield new TestResponse().setId(`${request.getId()}-0`);
+      yield new TestResponse().setId(`${request.getId()}-1`);
+    },
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const address = `localhost:${await getPort()}`;
+
+  await server.listen(address);
+
+  const channel = createChannel(address);
+  const client = createClientFactory()
+    .use(createTestClientMiddleware('testOption', actions))
+    .create(TestService, channel);
+
+  const responses: any[] = [];
+
+  for await (const response of client.testServerStream(
+    new TestRequest().setId('test'),
+    {
+      testOption: 'test-value',
+    },
+  )) {
+    responses.push(response);
+
+    break;
+  }
+
+  expect(responses).toMatchInlineSnapshot(`
+    Array [
+      nice_grpc.test.TestResponse {
+        "id": "test-0",
+      },
+    ]
+  `);
+
+  expect(actions).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "options": Object {
+          "testOption": "test-value",
+        },
+        "requestStream": false,
+        "responseStream": true,
+        "type": "start",
+      },
+      Object {
+        "request": nice_grpc.test.TestRequest {
+          "id": "test",
+        },
+        "type": "request",
+      },
+      Object {
+        "response": nice_grpc.test.TestResponse {
+          "id": "test-0",
+        },
+        "type": "response",
+      },
+      Object {
+        "error": [ClientError: /nice_grpc.test.Test/TestServerStream CANCELLED: Stream iteration was aborted by client],
+        "type": "error",
+      },
+    ]
+  `);
+
+  channel.close();
+
+  await server.shutdown();
+});

--- a/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
@@ -4,6 +4,8 @@ import {
   CallOptions,
   ClientMiddleware,
   MethodDescriptor,
+  ClientError,
+  Status,
 } from 'nice-grpc-common';
 import {isAbortError, throwIfAborted, waitForEvent} from 'abort-controller-x';
 import AbortController, {AbortSignal} from 'node-abort-controller';
@@ -148,8 +150,26 @@ export function createBidiStreamingMethod<Request, Response>(
 
             return result;
           },
-          return() {
-            return iterator.return();
+          async return() {
+            // if the iteration was aborted by `break` or `return` or `throw`
+            // inside the for .. of loop, let the middleware know by throwing
+            // an error to the generator
+
+            const error = new ClientError(
+              definition.path,
+              Status.CANCELLED,
+              'Stream iteration was aborted by client',
+            );
+
+            try {
+              return await iterator.throw(error);
+            } catch (err) {
+              if (err === error) {
+                return {done: true, value: undefined};
+              }
+
+              throw err;
+            }
           },
           throw(err) {
             return iterator.throw(err);

--- a/packages/nice-grpc/src/client/createServerStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createServerStreamingMethod.ts
@@ -2,9 +2,11 @@ import {Client} from '@grpc/grpc-js';
 import {throwIfAborted} from 'abort-controller-x';
 import {
   CallOptions,
+  ClientError,
   ClientMiddleware,
   Metadata,
   MethodDescriptor,
+  Status,
 } from 'nice-grpc-common';
 import AbortController from 'node-abort-controller';
 import {
@@ -123,8 +125,26 @@ export function createServerStreamingMethod<Request, Response>(
 
             return result;
           },
-          return() {
-            return iterator.return();
+          async return() {
+            // if the iteration was aborted by `break` or `return` or `throw`
+            // inside the for .. of loop, let the middleware know by throwing
+            // an error to the generator
+
+            const error = new ClientError(
+              definition.path,
+              Status.CANCELLED,
+              'Stream iteration was aborted by client',
+            );
+
+            try {
+              return await iterator.throw(error);
+            } catch (err) {
+              if (err === error) {
+                return {done: true, value: undefined};
+              }
+
+              throw err;
+            }
           },
           throw(err) {
             return iterator.throw(err);


### PR DESCRIPTION
Prior to this change when a client aborted iteration on a server stream by `break` or `return` or `throw` inside the for .. of loop, client middlewares were silently aborted as well. Now they get a `CANCELLED` error instead.