### PR TITLE
feat!: use built-in `AbortController` instead of `node-abort-controller`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,16 +18,22 @@ jobs:
 
     strategy:
       matrix:
-        node-version:
-          - 16.x
-          - 18.x
+        environment:
+          - node-version: 12.x
+            node-options: --require "abort-controller/polyfill"
+          - node-version: '14.17'
+            node-options: --experimental-abortcontroller
+          - node-version: 16.x 
+          - node-version: 18.x 
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.environment.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.environment.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      - run: yarn test
+      - env:
+          NODE_OPTIONS: ${{ matrix.environment.node-options }}
+        run: yarn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      - run: yarn test
+      - run: cd packages/nice-grpc-web && yarn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         environment:
-          - node-version: 12.x
-            node-options: --require "abort-controller/polyfill"
           - node-version: '14.17'
             node-options: --experimental-abortcontroller
           - node-version: 16.x 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
         environment:
           - node-version: '14.17'
             node-options: --experimental-abortcontroller
-          - node-version: 16.x 
-          - node-version: 18.x 
+          - node-version: 16.x
+          - node-version: 18.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         environment:
-          - node-version: '14.0'
+          - node-version: '14.15'
             node-options: --require "abort-controller/polyfill"
           - node-version: '14.17'
             node-options: --experimental-abortcontroller

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      - run: cd packages/nice-grpc-web && yarn test
+      - run: yarn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
     strategy:
       matrix:
         environment:
+          - node-version: '14.0'
+            node-options: --require "abort-controller/polyfill"
           - node-version: '14.17'
             node-options: --experimental-abortcontroller
           - node-version: 16.x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
-          - 14.x
-          - "16.8"
+          - 16.x
+          - 18.x
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
+    "abort-controller": "^3.0.0",
     "jest": "^27.0.4",
     "lerna": "^4.0.0",
     "prettier": "^2.3.1",

--- a/packages/nice-grpc-client-middleware-deadline/package.json
+++ b/packages/nice-grpc-client-middleware-deadline/package.json
@@ -24,14 +24,13 @@
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",
     "@types/google-protobuf": "^3.7.4",
-    "abort-controller-x": "^0.2.6",
+    "abort-controller-x": "^0.4.0",
     "google-protobuf": "^3.14.0",
     "grpc-tools": "^1.10.0",
     "grpc_tools_node_protoc_ts": "^5.0.1",
     "nice-grpc": "^1.2.2"
   },
   "dependencies": {
-    "nice-grpc-common": "^1.1.0",
-    "node-abort-controller": "^2.0.0"
+    "nice-grpc-common": "^1.1.0"
   }
 }

--- a/packages/nice-grpc-client-middleware-deadline/src/index.ts
+++ b/packages/nice-grpc-client-middleware-deadline/src/index.ts
@@ -1,5 +1,4 @@
 import {ClientError, ClientMiddleware, Status} from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 
 export type DeadlineOptions = {
   deadline?: Date | number;

--- a/packages/nice-grpc-client-middleware-retry/README.md
+++ b/packages/nice-grpc-client-middleware-retry/README.md
@@ -72,13 +72,12 @@ const response = await client.exampleMethod(request, {
 
 ### Infinite retries
 
-You can also set `retryMaxAttempts` to `Infinity` and use `AbortSignal` to
+You can also set `retryMaxAttempts` to `Infinity` and use
+[`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to
 [cancel](https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc#cancelling-calls)
 the retried call:
 
 ```ts
-import AbortController from 'node-abort-controller';
-
 const abortController = new AbortController();
 
 setTimeout(() => {

--- a/packages/nice-grpc-client-middleware-retry/package.json
+++ b/packages/nice-grpc-client-middleware-retry/package.json
@@ -29,8 +29,7 @@
     "ts-proto": "^1.112.0"
   },
   "dependencies": {
-    "abort-controller-x": "^0.2.6",
-    "nice-grpc-common": "^1.1.0",
-    "node-abort-controller": "^2.0.0"
+    "abort-controller-x": "^0.4.0",
+    "nice-grpc-common": "^1.1.0"
   }
 }

--- a/packages/nice-grpc-client-middleware-retry/src/index.ts
+++ b/packages/nice-grpc-client-middleware-retry/src/index.ts
@@ -1,6 +1,5 @@
 import {delay, rethrowAbortError} from 'abort-controller-x';
 import {ClientError, ClientMiddleware, Status} from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 
 /**
  * These options are added to `CallOptions` by

--- a/packages/nice-grpc-common/package.json
+++ b/packages/nice-grpc-common/package.json
@@ -23,7 +23,6 @@
     "@tsconfig/recommended": "^1.0.1"
   },
   "dependencies": {
-    "node-abort-controller": "^2.0.0",
     "ts-error": "^1.0.6"
   }
 }

--- a/packages/nice-grpc-common/src/client/CallOptions.ts
+++ b/packages/nice-grpc-common/src/client/CallOptions.ts
@@ -1,5 +1,3 @@
-import {AbortSignal} from 'node-abort-controller';
-
 import {Metadata} from '../Metadata';
 
 /**

--- a/packages/nice-grpc-common/src/server/CallContext.ts
+++ b/packages/nice-grpc-common/src/server/CallContext.ts
@@ -1,5 +1,3 @@
-import {AbortSignal} from 'node-abort-controller';
-
 import {Metadata} from '../Metadata';
 
 /**

--- a/packages/nice-grpc-common/tsconfig.json
+++ b/packages/nice-grpc-common/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,

--- a/packages/nice-grpc-server-health/package.json
+++ b/packages/nice-grpc-server-health/package.json
@@ -23,8 +23,8 @@
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
   "license": "MIT",
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.8",
-    "@types/node": "^12.0.0",
+    "@tsconfig/node14": "^1.0.3",
+    "@types/node": "^14.18.23",
     "grpc-tools": "^1.10.0",
     "jest-os-detection": "^1.3.1",
     "mkdirp": "^1.0.4",
@@ -34,7 +34,7 @@
     "ts-proto": "^1.112.0"
   },
   "dependencies": {
-    "abort-controller-x": "^0.2.6",
+    "abort-controller-x": "^0.4.0",
     "nice-grpc": "^1.2.2",
     "protobufjs": "^6.11.2",
     "typed-emitter": "^2.0.0"

--- a/packages/nice-grpc-server-health/tsconfig.json
+++ b/packages/nice-grpc-server-health/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,

--- a/packages/nice-grpc-server-middleware-terminator/package.json
+++ b/packages/nice-grpc-server-middleware-terminator/package.json
@@ -24,14 +24,13 @@
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",
     "@types/defer-promise": "^1.0.0",
-    "abort-controller-x": "^0.2.6",
+    "abort-controller-x": "^0.4.0",
     "defer-promise": "^2.0.1",
     "grpc-tools": "^1.10.0",
     "nice-grpc": "^1.2.2",
     "ts-proto": "^1.112.0"
   },
   "dependencies": {
-    "nice-grpc-common": "^1.1.0",
-    "node-abort-controller": "^2.0.0"
+    "nice-grpc-common": "^1.1.0"
   }
 }

--- a/packages/nice-grpc-server-middleware-terminator/src/index.test.ts
+++ b/packages/nice-grpc-server-middleware-terminator/src/index.test.ts
@@ -1,7 +1,6 @@
 import {forever, isAbortError} from 'abort-controller-x';
 import defer from 'defer-promise';
 import {createChannel, createClient, createServer} from 'nice-grpc';
-import AbortController from 'node-abort-controller';
 import {TerminatorMiddleware} from '.';
 import {TestDefinition} from '../fixtures/test';
 

--- a/packages/nice-grpc-server-middleware-terminator/src/index.ts
+++ b/packages/nice-grpc-server-middleware-terminator/src/index.ts
@@ -5,7 +5,6 @@ import {
   ServerMiddlewareCall,
   Status,
 } from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 
 export type TerminatorContext = {
   abortOnTerminate(): void;

--- a/packages/nice-grpc-server-reflection/package.json
+++ b/packages/nice-grpc-server-reflection/package.json
@@ -27,7 +27,8 @@
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
   "license": "MIT",
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.8",
+    "@tsconfig/node14": "^1.0.3",
+    "@types/node": "^14.18.23",
     "cpr": "^3.0.1",
     "grpc-tools": "^1.11.0",
     "grpc_tools_node_protoc_ts": "^5.1.3",

--- a/packages/nice-grpc-server-reflection/tsconfig.json
+++ b/packages/nice-grpc-server-reflection/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,

--- a/packages/nice-grpc-web/README.md
+++ b/packages/nice-grpc-web/README.md
@@ -29,6 +29,13 @@ A Browser gRPC client library that is nice to you. Built on top of
   [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 - Middleware support via concise API that uses Async Generators.
 
+## Prerequisites
+
+Global
+[`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+is required. A [polyfill](https://www.npmjs.com/package/abort-controller) is
+available for older browsers.
+
 ## Installation
 
 ```

--- a/packages/nice-grpc-web/README.md
+++ b/packages/nice-grpc-web/README.md
@@ -273,7 +273,6 @@ A client call can be cancelled using
 [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 
 ```ts
-import AbortController from 'node-abort-controller';
 import {isAbortError} from 'abort-controller-x';
 
 const abortController = new AbortController();

--- a/packages/nice-grpc-web/package.json
+++ b/packages/nice-grpc-web/package.json
@@ -52,9 +52,8 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.15.0",
-    "abort-controller-x": "^0.2.6",
+    "abort-controller-x": "^0.4.0",
     "js-base64": "^3.7.2",
-    "nice-grpc-common": "^1.1.0",
-    "node-abort-controller": "^2.0.0"
+    "nice-grpc-common": "^1.1.0"
   }
 }

--- a/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
@@ -24,7 +24,7 @@ test('basic', async () => {
     },
   });
 
-  const address = `127.0.0.1:${await getPort()}`;
+  const address = `localhost:${await getPort()}`;
 
   await server.listen(address);
 
@@ -32,7 +32,7 @@ test('basic', async () => {
   const proxy = await startProxy(proxyPort, address);
 
   const channel = createChannel(
-    `http://127.0.0.1:${proxyPort}`,
+    `http://localhost:${proxyPort}`,
     WebsocketTransport(),
   );
   const client = createClient(Test, channel);

--- a/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
@@ -24,7 +24,7 @@ test.only('basic', async () => {
     },
   });
 
-  const address = `localhost:${await getPort()}`;
+  const address = `127.0.0.1:${await getPort()}`;
 
   await server.listen(address);
 
@@ -32,7 +32,7 @@ test.only('basic', async () => {
   const proxy = await startProxy(proxyPort, address);
 
   const channel = createChannel(
-    `http://localhost:${proxyPort}`,
+    `http://127.0.0.1:${proxyPort}`,
     WebsocketTransport(),
   );
   const client = createClient(Test, channel);

--- a/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
@@ -2,7 +2,6 @@ import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
 import {createServer, ServerError} from 'nice-grpc';
-import AbortController from 'node-abort-controller';
 import {createChannel, createClient, Metadata, Status} from '..';
 import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
 import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';

--- a/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
@@ -10,7 +10,7 @@ import {startProxy} from './utils/grpcwebproxy';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 import {WebsocketTransport} from './utils/WebsocketTransport';
 
-test('basic', async () => {
+test.only('basic', async () => {
   const server = createServer();
 
   server.add(TestService, {

--- a/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/bidiStreaming.ts
@@ -10,7 +10,7 @@ import {startProxy} from './utils/grpcwebproxy';
 import {throwUnimplemented} from './utils/throwUnimplemented';
 import {WebsocketTransport} from './utils/WebsocketTransport';
 
-test.only('basic', async () => {
+test('basic', async () => {
   const server = createServer();
 
   server.add(TestService, {

--- a/packages/nice-grpc-web/src/__tests__/clientStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/clientStreaming.ts
@@ -2,7 +2,6 @@ import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
 import {createServer, ServerError} from 'nice-grpc';
-import AbortController from 'node-abort-controller';
 import {createChannel, createClient, Metadata, Status} from '..';
 import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
 import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';

--- a/packages/nice-grpc-web/src/__tests__/serverStreaming.ts
+++ b/packages/nice-grpc-web/src/__tests__/serverStreaming.ts
@@ -2,7 +2,6 @@ import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
 import {createServer, ServerError} from 'nice-grpc';
-import AbortController from 'node-abort-controller';
 import {createChannel, createClient, Metadata, Status} from '..';
 import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
 import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';

--- a/packages/nice-grpc-web/src/__tests__/unary.ts
+++ b/packages/nice-grpc-web/src/__tests__/unary.ts
@@ -2,7 +2,6 @@ import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
 import {createServer, ServerError} from 'nice-grpc';
-import AbortController from 'node-abort-controller';
 import {createChannel, createClient, Metadata, Status} from '..';
 import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
 import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';

--- a/packages/nice-grpc-web/src/__tests__/utils/WebsocketTransport.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/WebsocketTransport.ts
@@ -19,7 +19,7 @@ export function WebsocketTransport(): TransportFactory {
 }
 
 function websocketRequest(options: TransportOptions): Transport {
-  console.log('websocketRequest', options);
+  // console.log('websocketRequest', options);
 
   let webSocketAddress = constructWebSocketAddress(options.url);
 
@@ -59,7 +59,7 @@ function websocketRequest(options: TransportOptions): Transport {
       ws = new WebSocket(webSocketAddress, ['grpc-websockets']);
       ws.binaryType = 'arraybuffer';
       ws.onopen = function () {
-        console.log('websocketRequest.onopen');
+        // console.log('websocketRequest.onopen');
         ws.send(headersToBytes(metadata));
 
         // send any messages that were passed to sendMessage before the connection was ready
@@ -69,12 +69,12 @@ function websocketRequest(options: TransportOptions): Transport {
       };
 
       ws.onclose = function (closeEvent) {
-        console.log('websocketRequest.onclose', closeEvent);
+        // console.log('websocketRequest.onclose', closeEvent);
         options.onEnd();
       };
 
       ws.onerror = function (error) {
-        console.log('websocketRequest.onerror', error);
+        // console.log('websocketRequest.onerror', error);
       };
 
       ws.onmessage = function (e) {
@@ -82,7 +82,7 @@ function websocketRequest(options: TransportOptions): Transport {
       };
     },
     cancel: () => {
-      console.log('websocket.abort');
+      // console.log('websocket.abort');
       ws.close();
     },
   };

--- a/packages/nice-grpc-web/src/__tests__/utils/WebsocketTransport.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/WebsocketTransport.ts
@@ -19,7 +19,7 @@ export function WebsocketTransport(): TransportFactory {
 }
 
 function websocketRequest(options: TransportOptions): Transport {
-  // console.log('websocketRequest', options);
+  console.log('websocketRequest', options);
 
   let webSocketAddress = constructWebSocketAddress(options.url);
 
@@ -59,7 +59,7 @@ function websocketRequest(options: TransportOptions): Transport {
       ws = new WebSocket(webSocketAddress, ['grpc-websockets']);
       ws.binaryType = 'arraybuffer';
       ws.onopen = function () {
-        // console.log('websocketRequest.onopen');
+        console.log('websocketRequest.onopen');
         ws.send(headersToBytes(metadata));
 
         // send any messages that were passed to sendMessage before the connection was ready
@@ -69,12 +69,12 @@ function websocketRequest(options: TransportOptions): Transport {
       };
 
       ws.onclose = function (closeEvent) {
-        // console.log('websocketRequest.onclose', closeEvent);
+        console.log('websocketRequest.onclose', closeEvent);
         options.onEnd();
       };
 
       ws.onerror = function (error) {
-        // console.log('websocketRequest.onerror', error);
+        console.log('websocketRequest.onerror', error);
       };
 
       ws.onmessage = function (e) {
@@ -82,7 +82,7 @@ function websocketRequest(options: TransportOptions): Transport {
       };
     },
     cancel: () => {
-      // console.log('websocket.abort');
+      console.log('websocket.abort');
       ws.close();
     },
   };

--- a/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
@@ -21,9 +21,11 @@ export async function startProxy(
       `--server_bind_address=localhost`,
       `--server_http_debug_port=${listenPort}`,
       `--run_tls_server=false`,
-      `--backend_addr=http://${backendAddress}`,
+      `--backend_addr=${backendAddress}`,
       `--use_websockets=true`,
-      `--allow_all_origins=true`
+      `--allow_all_origins=true`,
+      `--server_http_max_read_timeout=180s`,
+      `--server_http_max_write_timeout=180s`,
     ],
     {
       stdio: 'inherit',

--- a/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
@@ -23,9 +23,7 @@ export async function startProxy(
       `--run_tls_server=false`,
       `--backend_addr=${backendAddress}`,
       `--use_websockets=true`,
-      `--allow_all_origins=true`,
-      `--server_http_max_read_timeout=180s`,
-      `--server_http_max_write_timeout=180s`,
+      `--allow_all_origins=true`
     ],
     // {
     //   stdio: 'inherit',

--- a/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
@@ -21,7 +21,7 @@ export async function startProxy(
       `--server_bind_address=localhost`,
       `--server_http_debug_port=${listenPort}`,
       `--run_tls_server=false`,
-      `--backend_addr=${backendAddress}`,
+      `--backend_addr=http://${backendAddress}`,
       `--use_websockets=true`,
       `--allow_all_origins=true`
     ],

--- a/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
@@ -25,9 +25,9 @@ export async function startProxy(
       `--use_websockets=true`,
       `--allow_all_origins=true`
     ],
-    // {
-    //   stdio: 'inherit',
-    // },
+    {
+      stdio: 'inherit',
+    },
   );
 
   await waitUntilUsed(listenPort);

--- a/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
+++ b/packages/nice-grpc-web/src/__tests__/utils/grpcwebproxy.ts
@@ -18,7 +18,7 @@ export async function startProxy(
   const childProcess = spawn(
     executablePath,
     [
-      `--server_bind_address=localhost`,
+      `--server_bind_address=0.0.0.0`,
       `--server_http_debug_port=${listenPort}`,
       `--run_tls_server=false`,
       `--backend_addr=${backendAddress}`,
@@ -27,9 +27,9 @@ export async function startProxy(
       `--server_http_max_read_timeout=180s`,
       `--server_http_max_write_timeout=180s`,
     ],
-    {
-      stdio: 'inherit',
-    },
+    // {
+    //   stdio: 'inherit',
+    // },
   );
 
   await waitUntilUsed(listenPort);

--- a/packages/nice-grpc-web/src/client/createBidiStreamingMethod.ts
+++ b/packages/nice-grpc-web/src/client/createBidiStreamingMethod.ts
@@ -8,7 +8,6 @@ import {
 } from 'nice-grpc-common';
 import {grpc} from '@improbable-eng/grpc-web';
 import {AbortError, isAbortError, throwIfAborted} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {AsyncSink} from '../utils/AsyncSink';
 import {
   AnyMethodDefinition,

--- a/packages/nice-grpc-web/src/client/createClientStreamingMethod.ts
+++ b/packages/nice-grpc-web/src/client/createClientStreamingMethod.ts
@@ -8,7 +8,6 @@ import {
 } from 'nice-grpc-common';
 import {grpc} from '@improbable-eng/grpc-web';
 import {execute, isAbortError, throwIfAborted} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   AnyMethodDefinition,
   MethodDefinition,

--- a/packages/nice-grpc-web/src/client/createServerStreamingMethod.ts
+++ b/packages/nice-grpc-web/src/client/createServerStreamingMethod.ts
@@ -9,7 +9,6 @@ import {
   MethodDescriptor,
   Status,
 } from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 import {
   MethodDefinition,
   toGrpcWebMethodDefinition,

--- a/packages/nice-grpc-web/src/client/createUnaryMethod.ts
+++ b/packages/nice-grpc-web/src/client/createUnaryMethod.ts
@@ -8,7 +8,6 @@ import {
 } from 'nice-grpc-common';
 import {grpc} from '@improbable-eng/grpc-web';
 import {execute} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   MethodDefinition,
   toGrpcWebMethodDefinition,

--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -42,6 +42,15 @@ A Node.js gRPC library that is nice to you. Built on top of
 - Client and server middleware support via concise API that uses Async
   Generators.
 
+## Prerequisites
+
+Supports NodeJS 14+. Global `AbortController` is required which is
+[available in NodeJS](https://nodejs.org/api/globals.html#class-abortcontroller)
+since 15.0.0, NodeJS 14.17+ requires the
+[--experimental-abortcontroller](https://nodejs.org/docs/latest-v14.x/api/cli.html#cli_experimental_abortcontroller)
+flag. A [polyfill](https://www.npmjs.com/package/abort-controller) is available
+for older NodeJS versions.
+
 ## Installation
 
 ```

--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -804,7 +804,6 @@ A client call can be cancelled using
 [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 
 ```ts
-import AbortController from 'node-abort-controller';
 import {isAbortError} from 'abort-controller-x';
 
 const abortController = new AbortController();

--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -32,10 +32,11 @@
   "author": "Daniel Lytkin <aikoven@deeplay.io>",
   "license": "MIT",
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.8",
+    "@tsconfig/node14": "^1.0.3",
     "@types/defer-promise": "^1.0.0",
     "@types/get-port": "^4.2.0",
     "@types/google-protobuf": "^3.7.4",
+    "@types/node": "^14.18.23",
     "defer-promise": "^2.0.1",
     "get-port": "^5.1.1",
     "google-protobuf": "^3.14.0",
@@ -47,8 +48,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.6.1",
-    "abort-controller-x": "^0.2.4",
-    "nice-grpc-common": "^1.1.0",
-    "node-abort-controller": "^1.2.1"
+    "abort-controller-x": "^0.4.0",
+    "nice-grpc-common": "^1.1.0"
   }
 }

--- a/packages/nice-grpc/src/__tests__/bidiStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/bidiStreaming.ts
@@ -1,7 +1,6 @@
 import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   createChannel,
   createClient,

--- a/packages/nice-grpc/src/__tests__/clientStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/clientStreaming.ts
@@ -1,7 +1,6 @@
 import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   createChannel,
   createClient,

--- a/packages/nice-grpc/src/__tests__/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverStreaming.ts
@@ -1,7 +1,6 @@
 import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   createChannel,
   createClient,

--- a/packages/nice-grpc/src/__tests__/unary.ts
+++ b/packages/nice-grpc/src/__tests__/unary.ts
@@ -1,7 +1,6 @@
 import getPort = require('get-port');
 import defer = require('defer-promise');
 import {forever, isAbortError} from 'abort-controller-x';
-import AbortController from 'node-abort-controller';
 import {
   createChannel,
   createClient,

--- a/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
@@ -6,7 +6,6 @@ import {
   MethodDescriptor,
 } from 'nice-grpc-common';
 import {isAbortError, throwIfAborted, waitForEvent} from 'abort-controller-x';
-import AbortController, {AbortSignal} from 'node-abort-controller';
 import {isAsyncIterable} from '../utils/isAsyncIterable';
 import {patchClientWritableStream} from '../utils/patchClientWritableStream';
 import {readableToAsyncIterable} from '../utils/readableToAsyncIterable';

--- a/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createBidiStreamingMethod.ts
@@ -1,24 +1,25 @@
 import {Client, ClientWritableStream} from '@grpc/grpc-js';
+import {isAbortError, throwIfAborted, waitForEvent} from 'abort-controller-x';
 import {
-  Metadata,
   CallOptions,
   ClientMiddleware,
+  Metadata,
   MethodDescriptor,
 } from 'nice-grpc-common';
-import {isAbortError, throwIfAborted, waitForEvent} from 'abort-controller-x';
-import {isAsyncIterable} from '../utils/isAsyncIterable';
-import {patchClientWritableStream} from '../utils/patchClientWritableStream';
-import {readableToAsyncIterable} from '../utils/readableToAsyncIterable';
-import {
-  convertMetadataFromGrpcJs,
-  convertMetadataToGrpcJs,
-} from '../utils/convertMetadata';
-import {BidiStreamingClientMethod} from './Client';
-import {wrapClientError} from './wrapClientError';
 import {
   MethodDefinition,
   toGrpcJsMethodDefinition,
 } from '../service-definitions';
+import {CompatAbortSignal} from '../utils/compatAbortSignal';
+import {
+  convertMetadataFromGrpcJs,
+  convertMetadataToGrpcJs,
+} from '../utils/convertMetadata';
+import {isAsyncIterable} from '../utils/isAsyncIterable';
+import {patchClientWritableStream} from '../utils/patchClientWritableStream';
+import {readableToAsyncIterable} from '../utils/readableToAsyncIterable';
+import {BidiStreamingClientMethod} from './Client';
+import {wrapClientError} from './wrapClientError';
 
 /** @internal */
 export function createBidiStreamingMethod<Request, Response>(
@@ -46,12 +47,10 @@ export function createBidiStreamingMethod<Request, Response>(
       );
     }
 
-    const {
-      metadata = Metadata(),
-      signal = new AbortController().signal,
-      onHeader,
-      onTrailer,
-    } = options;
+    const {metadata = Metadata(), onHeader, onTrailer} = options;
+
+    const signal = (options.signal ??
+      new AbortController().signal) as CompatAbortSignal;
 
     const pipeAbortController = new AbortController();
 

--- a/packages/nice-grpc/src/client/createClientStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createClientStreamingMethod.ts
@@ -11,7 +11,6 @@ import {
   Metadata,
   MethodDescriptor,
 } from 'nice-grpc-common';
-import AbortController, {AbortSignal} from 'node-abort-controller';
 import {
   MethodDefinition,
   toGrpcJsMethodDefinition,

--- a/packages/nice-grpc/src/client/createServerStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createServerStreamingMethod.ts
@@ -10,6 +10,7 @@ import {
   MethodDefinition,
   toGrpcJsMethodDefinition,
 } from '../service-definitions';
+import {CompatAbortSignal} from '../utils/compatAbortSignal';
 import {
   convertMetadataFromGrpcJs,
   convertMetadataToGrpcJs,
@@ -45,12 +46,10 @@ export function createServerStreamingMethod<Request, Response>(
       );
     }
 
-    const {
-      metadata = Metadata(),
-      signal = new AbortController().signal,
-      onHeader,
-      onTrailer,
-    } = options;
+    const {metadata = Metadata(), onHeader, onTrailer} = options;
+
+    const signal = (options.signal ??
+      new AbortController().signal) as CompatAbortSignal;
 
     const call = client.makeServerStreamRequest(
       grpcMethodDefinition.path,

--- a/packages/nice-grpc/src/client/createServerStreamingMethod.ts
+++ b/packages/nice-grpc/src/client/createServerStreamingMethod.ts
@@ -6,7 +6,6 @@ import {
   Metadata,
   MethodDescriptor,
 } from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 import {
   MethodDefinition,
   toGrpcJsMethodDefinition,

--- a/packages/nice-grpc/src/client/createUnaryMethod.ts
+++ b/packages/nice-grpc/src/client/createUnaryMethod.ts
@@ -6,7 +6,6 @@ import {
   Metadata,
   MethodDescriptor,
 } from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 import {
   MethodDefinition,
   toGrpcJsMethodDefinition,

--- a/packages/nice-grpc/src/server/createCallContext.ts
+++ b/packages/nice-grpc/src/server/createCallContext.ts
@@ -1,6 +1,5 @@
 import {ServerSurfaceCall} from '@grpc/grpc-js/build/src/server-call';
 import {CallContext, Metadata} from 'nice-grpc-common';
-import AbortController from 'node-abort-controller';
 import {
   convertMetadataFromGrpcJs,
   convertMetadataToGrpcJs,

--- a/packages/nice-grpc/src/utils/compatAbortSignal.ts
+++ b/packages/nice-grpc/src/utils/compatAbortSignal.ts
@@ -1,0 +1,4 @@
+export type CompatAbortSignal = AbortSignal & {
+  addEventListener(type: 'abort', listener: () => void): void;
+  removeEventListener(type: 'abort', listener: () => void): void;
+};

--- a/packages/nice-grpc/tsconfig.json
+++ b/packages/nice-grpc/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,10 +1639,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsconfig/node12@^1.0.8":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
-  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+"@tsconfig/node14@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/recommended@^1.0.1":
   version "1.0.1"
@@ -1753,15 +1753,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "15.12.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
-  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
-
-"@types/node@^12.0.0":
-  version "12.20.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.19.tgz#538e61fc220f77ae4a4663c3d8c3cb391365c209"
-  integrity sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^14.18.23":
+  version "14.18.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.23.tgz#70f5f20b0b1b38f696848c1d3647bb95694e615e"
+  integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1830,12 +1825,10 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abort-controller-x@^0.2.4, abort-controller-x@^0.2.6:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.2.7.tgz#6fa9be5b278b9c533d4d078d0ba660d40683907e"
-  integrity sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==
-  dependencies:
-    node-abort-controller "^1.2.1 || ^2.0.0"
+abort-controller-x@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.4.0.tgz#fde25da52548c7ff3d8b3b32dffc943452874d5f"
+  integrity sha512-cuNbw3c/SvEOkWkgxoWOOS3QzcTCC6YXCFH6oTZ/jvjZPBhkjaoUyCLwdAViRRhYmluJPD7vGaTLkHCp67xQVQ==
 
 acorn-globals@^6.0.0:
   version "6.0.0"
@@ -5014,16 +5007,6 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-node-abort-controller@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.2.1.tgz#1eddb57eb8fea734198b11b28857596dc6165708"
-  integrity sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ==
-
-"node-abort-controller@^1.2.1 || ^2.0.0", node-abort-controller@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-2.0.0.tgz#800e0d250d3b977175e48df4f74c2d3960076a79"
-  integrity sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA==
 
 node-fetch@^2.6.1:
   version "2.6.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,6 +1830,13 @@ abort-controller-x@^0.4.0:
   resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.4.0.tgz#fde25da52548c7ff3d8b3b32dffc943452874d5f"
   integrity sha512-cuNbw3c/SvEOkWkgxoWOOS3QzcTCC6YXCFH6oTZ/jvjZPBhkjaoUyCLwdAViRRhYmluJPD7vGaTLkHCp67xQVQ==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -2997,6 +3004,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^4.0.4:
   version "4.0.7"


### PR DESCRIPTION
AbortController is [available in NodeJS](https://nodejs.org/api/globals.html#class-abortcontroller) since 15.0.0, NodeJS 14.17+ requires the [--experimental-abortcontroller](https://nodejs.org/docs/latest-v14.x/api/cli.html#cli_experimental_abortcontroller) flag. A [polyfill](https://www.npmjs.com/package/abort-controller) is available for older NodeJS versions and browsers.

Support for NodeJS 12 is dropped.

Closes #158