### PR TITLE
feat(nice-grpc): include support for implicit secure protocol

### DIFF
--- a/packages/nice-grpc/src/__tests__/channel.ts
+++ b/packages/nice-grpc/src/__tests__/channel.ts
@@ -1,6 +1,6 @@
 import getPort = require('get-port');
 import {randomBytes} from 'crypto';
-import {createChannel, createServer, waitForChannelReady, Channel} from '..';
+import {createChannel, createServer, waitForChannelReady, Channel, ChannelCredentials} from '..';
 
 test('implicit protocol', async () => {
   const address = `localhost:${await getPort()}`;
@@ -42,12 +42,151 @@ test('default port', async () => {
   secureChannel.close();
 });
 
-test('unknown protocol', () => {
+test('implicit protocol, secure credentials', () => {
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(address, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${443}"`);
+});
+
+test('implicit protocol, secure credentials, custom port', () => {
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(`${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${port}"`);
+});
+
+test('implicit protocol, insecure credentials', () => {
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(address, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${80}"`);
+});
+
+test('implicit protocol, insecure credentials, custom port', () => {
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(`${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${port}"`);
+});
+
+test('implicit protocol, no credentials', () => {
+  const address = 'private.host.private';
+  const channel = createChannel(address);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${80}"`);
+});
+
+test('explicit protocol, insecure credentials', () => {
+  const protocol = 'https://'
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(`${protocol}${address}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${443}"`);
+});
+
+test('explicit protocol, insecure credentials, custom port', () => {
+  const protocol = 'http://'
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(`${protocol}${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${port}"`);
+});
+
+test('explicit protocol, secure credentials', () => {
+  const protocol = 'http://'
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(`${protocol}${address}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${443}"`);
+});
+
+test('explicit protocol, secure credentials, custom port', () => {
+  const protocol = 'http://'
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(`${protocol}${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${port}"`);
+});
+
+test('explicit protocol, no credentials', () => {
+  const protocol = 'https://'
+  const address = 'private.host.private';
+  const channel = createChannel(`${protocol}${address}`);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}:${443}"`);
+});
+
+test('unknown protocol, no credentials', () => {
   const address = 'consul://server';
   const channel = createChannel(address);
 
   expect(channel).toBeInstanceOf(Channel);
   expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${address}"`);
+});
+
+test('unknown protocol, insecure credentials', () => {
+  const protocol = 'consul://'
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(`${protocol}${address}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${protocol}${address}"`);
+});
+
+test('unknown protocol, insecure credentials, custom port', () => {
+  const protocol = 'consul://'
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createInsecure();
+  const channel = createChannel(`${protocol}${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${protocol}${address}:${port}"`);
+});
+
+test('unknown protocol, secure credentials', () => {
+  const protocol = 'consul://'
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(`${protocol}${address}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${protocol}${address}"`);
+});
+
+test('unknown protocol, secure credentials, custom port', () => {
+  const protocol = 'consul://'
+  const port = "8080"
+  const address = 'private.host.private';
+  const credentials = ChannelCredentials.createSsl();
+  const channel = createChannel(`${protocol}${address}:${port}`, credentials);
+
+  expect(channel).toBeInstanceOf(Channel);
+  expect(channel.getTarget()).toMatchInlineSnapshot(`"dns:${protocol}${address}:${port}"`);
 });
 
 test('waitForChannelReady deadline', async () => {

--- a/packages/nice-grpc/src/client/channel.ts
+++ b/packages/nice-grpc/src/client/channel.ts
@@ -5,31 +5,26 @@ import {
   connectivityState,
 } from '@grpc/grpc-js';
 
+const knownProtocols = new Set(["http", "https"]);
+
 export function createChannel(
   address: string,
   credentials?: ChannelCredentials,
   options: ChannelOptions = {},
 ): Channel {
   const match = /^(?:([^:]+):\/\/)?(.*?)(?::(\d+))?$/.exec(address);
+  if (match == null) throw new Error(`Invalid address: '${address}'`);
 
-  if (match == null) {
-    throw new Error(`Invalid address: '${address}'`);
-  }
+  let [, protocol, host, port] = match;
 
-  const [, protocol = 'http', host, port = protocol === 'http' ? '80' : '443'] =
-    match;
+  const knownProtocol = !protocol || knownProtocols.has(protocol);
+  const isSecure = credentials?._isSecure() || protocol?.includes("https");
 
-  if (protocol === 'http') {
-    credentials ??= ChannelCredentials.createInsecure();
-  } else if (protocol === 'https') {
-    credentials ??= ChannelCredentials.createSsl();
-  } else {
-    credentials ??= ChannelCredentials.createInsecure();
+  credentials ??= isSecure ? ChannelCredentials.createSsl() : ChannelCredentials.createInsecure();
+  port ??= isSecure ? '443' : '80';
 
-    return new Channel(address, credentials, options);
-  }
-
-  return new Channel(`${host}:${port}`, credentials, options);
+  let target = knownProtocol ? `${host}:${port}` : address;
+  return new Channel(target, credentials, options);
 }
 
 export async function waitForChannelReady(


### PR DESCRIPTION
If a client is set up using **secure credentials** with only the hostname **and no protocol**, the current logic defaults to the insecure 80 port.

This refactors the `createChannel` logic and then adds some logic to consider the possibility that the credentials passed in are already set up to be secure.

Since [ChannelCredentials is an abstract class](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/channel-credentials.ts#L66) - we should always expect to be passed an implemented credential object that has _isSecure() set to either [true](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/channel-credentials.ts#L220) or [false](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/channel-credentials.ts#L184) (or nothing at all, which then defaults insecure).