### PR TITLE
fix: fix destructing error if there is no call.method.options

### DIFF
--- a/packages/nice-grpc-client-middleware-retry/src/index.ts
+++ b/packages/nice-grpc-client-middleware-retry/src/index.ts
@@ -13,7 +13,7 @@ export type RetryOptions = {
    *
    *     option idempotency_level = IDEMPOTENT;
    *
-   * then the default is `true`. Otherwise the default is `false`.
+   * then the default is `true`. Otherwise, the default is `false`.
    *
    * Method options currently work only when compiling with `ts-proto`.
    */
@@ -24,7 +24,7 @@ export type RetryOptions = {
    * Defaults to 1000.
    *
    * Example: if `retryBaseDelayMs` is 100, then retries will be attempted in
-   * 100ms, 200ms, 400ms etc (not counting jitter).
+   * 100ms, 200ms, 400ms etc. (not counting jitter).
    */
   retryBaseDelayMs?: number;
   /**
@@ -33,7 +33,7 @@ export type RetryOptions = {
    * Defaults to 30 seconds.
    *
    * Example: if `retryBaseDelayMs` is 1000 and `retryMaxDelayMs` is 3000, then
-   * retries will be attempted in 1000ms, 2000ms, 3000ms, 3000ms etc (not
+   * retries will be attempted in 1000ms, 2000ms, 3000ms, 3000ms etc. (not
    * counting jitter).
    */
   retryMaxDelayMs?: number;
@@ -72,7 +72,7 @@ const defaultRetryableStatuses: Status[] = [
  */
 export const retryMiddleware: ClientMiddleware<RetryOptions> =
   async function* retryMiddleware(call, options) {
-    const {idempotencyLevel} = call.method.options;
+    const {idempotencyLevel} = call.method.options ?? {};
     const isIdempotent =
       idempotencyLevel === 'IDEMPOTENT' ||
       idempotencyLevel === 'NO_SIDE_EFFECTS';


### PR DESCRIPTION
If protobuf files were compiled without `--ts_proto_opt=outputServices=generic-definitions`, there will be no `call.method.options`. As a result, trying to destructure it and get the `idempotencyLevel` value will result in the following error.
```
TypeError: Cannot destructure property 'idempotencyLevel' of 'call.method.options' as it is undefined.
```

The fix makes the retry middleware usable for more people who use different ts_proto options and are willing to manually provide retry options to API calls.