### PR TITLE
fix(nice-grpc): fix runtime detection of grpc-js service definitions

### DIFF
--- a/packages/nice-grpc/src/service-definitions/grpc-js.ts
+++ b/packages/nice-grpc/src/service-definitions/grpc-js.ts
@@ -62,5 +62,10 @@ export function fromGrpcJsServiceDefinition(
 export function isGrpcJsServiceDefinition(
   definition: CompatServiceDefinition,
 ): definition is grpc.ServiceDefinition {
-  return 'prototype' in definition;
+  return Object.values(definition).every(
+    value =>
+      typeof value === 'object' &&
+      value != null &&
+      typeof value.path === 'string',
+  );
 }


### PR DESCRIPTION
Prior to this fix the library incorrectly detected `grpc-js` service definitions generated by `ts-proto` as `ts-proto` generic definitions.

Closes #291