### PR TITLE
feat(nice-grpc-client-middleware-retry): add `CANCELLED` to retryable codes

### DIFF
--- a/packages/nice-grpc-client-middleware-retry/src/index.ts
+++ b/packages/nice-grpc-client-middleware-retry/src/index.ts
@@ -46,7 +46,7 @@ export type RetryOptions = {
   /**
    * Array of retryable status codes.
    *
-   * Default is `[UNKNOWN, INTERNAL, UNAVAILABLE]`.
+   * Default is `[UNKNOWN, INTERNAL, UNAVAILABLE, CANCELLED]`.
    */
   retryableStatuses?: Status[];
   /**
@@ -64,6 +64,10 @@ const defaultRetryableStatuses: Status[] = [
   Status.UNKNOWN,
   Status.INTERNAL,
   Status.UNAVAILABLE,
+  // Server may return `CANCELLED` if it is shutting down. We can distinguish
+  // this from client-initiated cancellations because these are returned as
+  // `AbortError`s.
+  Status.CANCELLED,
 ];
 
 /**


### PR DESCRIPTION
Server may return `CANCELLED` status on shutdown.