### PR TITLE
fix(nice-grpc): ts-proto method definition

### DIFF
--- a/packages/nice-grpc-web/src/service-definitions/ts-proto.ts
+++ b/packages/nice-grpc-web/src/service-definitions/ts-proto.ts
@@ -16,6 +16,7 @@ export type TsProtoMethodDefinition<Request, Response> = {
   responseStream: boolean;
   options: {
     idempotencyLevel?: 'IDEMPOTENT' | 'NO_SIDE_EFFECTS';
+    _unknownFields?: {};
   };
 };
 

--- a/packages/nice-grpc/src/service-definitions/ts-proto.ts
+++ b/packages/nice-grpc/src/service-definitions/ts-proto.ts
@@ -16,6 +16,7 @@ export type TsProtoMethodDefinition<Request, Response> = {
   responseStream: boolean;
   options: {
     idempotencyLevel?: 'IDEMPOTENT' | 'NO_SIDE_EFFECTS';
+    _unknownFields?: {};
   };
 };
 


### PR DESCRIPTION
Updated ts-proto method definition to reflect this change: https://github.com/stephenh/ts-proto/pull/801