### PR TITLE
fix(nice-grpc-web): correctly handle trailers-only responses

### DIFF
--- a/packages/nice-grpc-web/src/client/parseTrailer.ts
+++ b/packages/nice-grpc-web/src/client/parseTrailer.ts
@@ -27,7 +27,15 @@ export function parseTrailer(trailer: Metadata): ParsedTrailer {
     throw new Error('Received no status code from server');
   }
 
-  const message = trailer.get('grpc-message');
+  let message = trailer.get('grpc-message');
+
+  if (message != null) {
+    try {
+      message = decodeURIComponent(message);
+    } catch {
+      // ignore
+    }
+  }
 
   const trailerCopy = Metadata(trailer);
   trailerCopy.delete('grpc-status');


### PR DESCRIPTION
- gRPC status and message received in trailers-only response (the headers) get precedence over ones mapped from HTTP status codes.
- Actual trailer is tolerated in trailers-only response only if it's empty.
- `grpc-message` header value is decoded using URL encoding.

Closes #345 