### PR TITLE
add cache field to FetchTransportConfig

### DIFF
--- a/packages/nice-grpc-web/src/client/transports/fetch.ts
+++ b/packages/nice-grpc-web/src/client/transports/fetch.ts
@@ -5,6 +5,7 @@ import {Transport} from '../Transport';
 
 export interface FetchTransportConfig {
   credentials?: RequestCredentials;
+  cache?: RequestCache; // defaults to no-cache if unspecified
 }
 
 /**
@@ -53,7 +54,7 @@ export function FetchTransport(config?: FetchTransportConfig): Transport {
       body: requestBody,
       headers: metadataToHeaders(metadata),
       signal,
-      cache: 'no-cache',
+      cache: config?.cache ? config.cache : 'no-cache',
       ['duplex' as any]: 'half',
       credentials: config?.credentials,
     });

--- a/packages/nice-grpc-web/src/client/transports/fetch.ts
+++ b/packages/nice-grpc-web/src/client/transports/fetch.ts
@@ -5,7 +5,7 @@ import {Transport} from '../Transport';
 
 export interface FetchTransportConfig {
   credentials?: RequestCredentials;
-  cache?: RequestCache; // defaults to no-cache if unspecified
+  cache?: RequestCache;
 }
 
 /**
@@ -54,7 +54,7 @@ export function FetchTransport(config?: FetchTransportConfig): Transport {
       body: requestBody,
       headers: metadataToHeaders(metadata),
       signal,
-      cache: config?.cache ? config.cache : 'no-cache',
+      cache: config?.cache,
       ['duplex' as any]: 'half',
       credentials: config?.credentials,
     });


### PR DESCRIPTION
Resolve https://github.com/deeplay-io/nice-grpc/issues/349 by adding an optional cache param for FetchTransport which allows developers to specify the cache strategy on fetch requests for nice-grpc-web