### PR TITLE
feat(nice-grpc-error-details): include support for violation type of errors in rich client error detail instance

### DIFF
--- a/packages/nice-grpc-error-details/src/ErrorDetails.ts
+++ b/packages/nice-grpc-error-details/src/ErrorDetails.ts
@@ -1,11 +1,14 @@
 import {
   BadRequest,
+  BadRequest_FieldViolation,
   DebugInfo,
   ErrorInfo,
   Help,
   LocalizedMessage,
   PreconditionFailure,
+  PreconditionFailure_Violation,
   QuotaFailure,
+  QuotaFailure_Violation,
   RequestInfo,
   ResourceInfo,
   RetryInfo,
@@ -17,9 +20,12 @@ export type ErrorDetails =
   | RetryInfo
   | DebugInfo
   | QuotaFailure
+  | QuotaFailure_Violation
   | ErrorInfo
   | PreconditionFailure
+  | PreconditionFailure_Violation
   | BadRequest
+  | BadRequest_FieldViolation
   | RequestInfo
   | ResourceInfo
   | Help
@@ -30,9 +36,12 @@ const knownMessages = [
   RetryInfo,
   DebugInfo,
   QuotaFailure,
+  QuotaFailure_Violation,
   ErrorInfo,
   PreconditionFailure,
+  PreconditionFailure_Violation,
   BadRequest,
+  BadRequest_FieldViolation,
   RequestInfo,
   ResourceInfo,
   Help,

--- a/packages/nice-grpc-error-details/src/index.test.ts
+++ b/packages/nice-grpc-error-details/src/index.test.ts
@@ -13,46 +13,24 @@ import {
   errorDetailsServerMiddleware,
   Help,
   PreconditionFailure,
+  PreconditionFailure_Violation,
+  BadRequest_FieldViolation,
+  QuotaFailure_Violation,
   RichClientError,
   RichServerError,
+  ErrorDetails,
 } from '.';
 import {CustomErrorDetail, TestDefinition} from '../fixtures/test';
 
-test('server and client', async () => {
+const beforeEachServerAndClientTest = async (
+  code: Status,
+  extraErrorDetail: ErrorDetails[],
+) => {
   const server = createServer().use(errorDetailsServerMiddleware);
 
   server.add(TestDefinition, {
     async testUnary() {
-      throw new RichServerError(Status.FAILED_PRECONDITION, 'test-message', [
-        PreconditionFailure.fromPartial({
-          violations: [
-            {
-              type: 'type1',
-              subject: 'subject1',
-              description: 'description1,',
-            },
-            {
-              type: 'type2',
-              subject: 'subject2',
-              description: 'description2,',
-            },
-          ],
-        }),
-        Help.fromPartial({
-          links: [
-            {
-              url: 'help-url',
-              description: 'help-description',
-            },
-          ],
-        }),
-        Any.fromPartial({
-          typeUrl: `types.googleapis.com/${CustomErrorDetail.$type}`,
-          value: CustomErrorDetail.encode(
-            CustomErrorDetail.fromPartial({test: 'custom-test'}),
-          ).finish(),
-        }),
-      ]);
+      throw new RichServerError(code, 'test-message', extraErrorDetail);
     },
   });
 
@@ -63,11 +41,6 @@ test('server and client', async () => {
   const rawClient = createClient(TestDefinition, channel);
 
   const rawClientError = await rawClient.testUnary({}).catch(err => err);
-  expect(rawClientError).toBeInstanceOf(ClientError);
-  expect(rawClientError.name).toBe('ClientError');
-  expect(rawClientError.path).toBe('/nice_grpc.test.Test/TestUnary');
-  expect(rawClientError.code).toBe(Status.FAILED_PRECONDITION);
-  expect(rawClientError.details).toBe('test-message');
 
   const clientWithMiddleware = createClientFactory()
     .use(errorDetailsClientMiddleware)
@@ -86,45 +59,136 @@ test('server and client', async () => {
     )
     .catch(err => err);
 
+  channel.close();
+  await server.shutdown();
+
+  expect(rawClientError).toBeInstanceOf(ClientError);
+  expect(rawClientError.name).toBe('ClientError');
+  expect(rawClientError.path).toBe('/nice_grpc.test.Test/TestUnary');
+  expect(rawClientError.details).toBe('test-message');
+
   expect(trailer?.has('grpc-status-details-bin')).toBe(true);
 
   expect(richClientError).toBeInstanceOf(ClientError);
   expect(richClientError).toBeInstanceOf(RichClientError);
   expect(richClientError.name).toBe('RichClientError');
   expect(richClientError.path).toBe('/nice_grpc.test.Test/TestUnary');
-  expect(richClientError.code).toBe(Status.FAILED_PRECONDITION);
   expect(richClientError.details).toBe('test-message');
-  expect(richClientError.extra).toEqual([
-    PreconditionFailure.fromPartial({
-      violations: [
-        {
-          type: 'type1',
-          subject: 'subject1',
-          description: 'description1,',
-        },
-        {
-          type: 'type2',
-          subject: 'subject2',
-          description: 'description2,',
-        },
-      ],
-    }),
-    Help.fromPartial({
-      links: [
-        {
-          url: 'help-url',
-          description: 'help-description',
-        },
-      ],
-    }),
-    Any.fromPartial({
-      typeUrl: `types.googleapis.com/${CustomErrorDetail.$type}`,
-      value: CustomErrorDetail.encode(
-        CustomErrorDetail.fromPartial({test: 'custom-test'}),
-      ).finish(),
-    }),
-  ]);
 
-  channel.close();
-  await server.shutdown();
+  return {
+    rawClientError,
+    richClientError,
+  };
+};
+
+describe('server and client', () => {
+  const helpPartial = Help.fromPartial({
+    links: [
+      {
+        url: 'help-url',
+        description: 'help-description',
+      },
+    ],
+  });
+  const anyPartial = Any.fromPartial({
+    typeUrl: `types.googleapis.com/${CustomErrorDetail.$type}`,
+    value: CustomErrorDetail.encode(
+      CustomErrorDetail.fromPartial({test: 'custom-test'}),
+    ).finish(),
+  });
+
+  it('should be instance of preconditionFailure when server throws preconditionFailure error', async () => {
+    const preConditionFailError = [
+      PreconditionFailure.fromPartial({
+        violations: [
+          {
+            type: 'type1',
+            subject: 'subject1',
+            description: 'description1',
+          },
+          {
+            type: 'type2',
+            subject: 'subject2',
+            description: 'description2',
+          },
+        ],
+      }),
+      helpPartial,
+      anyPartial,
+    ];
+    const {rawClientError, richClientError} =
+      await beforeEachServerAndClientTest(
+        Status.FAILED_PRECONDITION,
+        preConditionFailError,
+      );
+
+    expect(rawClientError.code).toBe(Status.FAILED_PRECONDITION);
+
+    expect(richClientError.code).toBe(Status.FAILED_PRECONDITION);
+    expect(richClientError.extra).toEqual(preConditionFailError);
+  });
+
+  it('should be instance of preconditionFailure violation when server throws preconditionFailureViolation error', async () => {
+    const preconditionFailureViolationError = [
+      PreconditionFailure_Violation.fromPartial({
+        type: 'type',
+        subject: 'subject',
+        description: 'description',
+      }),
+      helpPartial,
+      anyPartial,
+    ];
+    const {rawClientError, richClientError} =
+      await beforeEachServerAndClientTest(
+        Status.FAILED_PRECONDITION,
+        preconditionFailureViolationError,
+      );
+
+    expect(rawClientError.code).toBe(Status.FAILED_PRECONDITION);
+
+    expect(richClientError.code).toBe(Status.FAILED_PRECONDITION);
+    expect(richClientError.extra).toEqual(preconditionFailureViolationError);
+  });
+
+  it('should be instance of badRequest field violation when server throws BadRequest_FieldViolation error', async () => {
+    const badRequestFieldViolationError = [
+      BadRequest_FieldViolation.fromPartial({
+        field: 'field',
+        description: 'description',
+      }),
+      helpPartial,
+      anyPartial,
+    ];
+    const {rawClientError, richClientError} =
+      await beforeEachServerAndClientTest(
+        Status.INVALID_ARGUMENT,
+        badRequestFieldViolationError,
+      );
+
+    expect(rawClientError.code).toBe(Status.INVALID_ARGUMENT);
+
+    expect(richClientError.code).toBe(Status.INVALID_ARGUMENT);
+    expect(richClientError.extra).toEqual(badRequestFieldViolationError);
+  });
+
+  it('should be instance of quota failure violation when server throws QuotaFailure_Violation error', async () => {
+    const quotaFailureViolationError = [
+      QuotaFailure_Violation.fromPartial({
+        subject: 'subject',
+        description: 'description',
+      }),
+      helpPartial,
+      anyPartial,
+    ];
+    const {rawClientError, richClientError} =
+      await beforeEachServerAndClientTest(
+        Status.DEADLINE_EXCEEDED,
+        quotaFailureViolationError,
+      );
+
+    expect(rawClientError.code).toBe(Status.DEADLINE_EXCEEDED);
+
+    expect(richClientError.code).toBe(Status.DEADLINE_EXCEEDED);
+    expect(richClientError.extra).toEqual(quotaFailureViolationError);
+  });
 });


### PR DESCRIPTION
This PR is to support `BadRequest_FieldViolation/PreconditionFailure_Violation/QuotaFailure_Violation` errors to the rich client error instance. As per current behaviour, detail are mapped to `Any` type since these violations type of errors are currently not supported in the library.

I have a server in Golang side which can throw violation errors too in the error response. Hence this library should also support the ability to map the violation errors correctly to RichClientError instance

Resolution to the issue mentioned in this [thread](https://github.com/deeplay-io/nice-grpc/issues/369)

Closes #369