### PR TITLE
fix(nice-grpc-web): don't put stack traces to internal and transport error messages

### DIFF
--- a/packages/nice-grpc-web/src/client/makeInternalErrorMessage.ts
+++ b/packages/nice-grpc-web/src/client/makeInternalErrorMessage.ts
@@ -2,17 +2,7 @@
 export function makeInternalErrorMessage(err: any): string {
   if (err == null || typeof err !== 'object') {
     return String(err);
-  } else if (typeof err.stack === 'string') {
-    if (typeof err.message === 'string') {
-      if (err.stack.startsWith(err.message)) {
-        return err.stack;
-      } else {
-        return err.message + '\n' + err.stack;
-      }
-    }
-
-    return err.stack;
-  } else if (err.message) {
+  } else if (typeof err.message === 'string') {
     return err.message;
   } else {
     return JSON.stringify(err);

--- a/packages/nice-grpc-web/test-server/traefik.ts
+++ b/packages/nice-grpc-web/test-server/traefik.ts
@@ -1,11 +1,7 @@
 import fs from 'fs/promises';
 import * as path from 'path';
 import {env} from 'string-env-interpolation';
-import {GenericContainer} from 'testcontainers';
-import {
-  HostPortWaitStrategy,
-  LogWaitStrategy,
-} from 'testcontainers/dist/wait-strategy';
+import {GenericContainer, Wait} from 'testcontainers';
 import * as tmp from 'tmp';
 
 export async function startTraefikProxy(
@@ -83,7 +79,7 @@ export async function startTraefikProxy(
         ipAddress: 'host-gateway',
       },
     ])
-    .withWaitStrategy(new LogWaitStrategy(/traefik-internal-recovery/))
+    .withWaitStrategy(Wait.forLogMessage(/traefik-internal-recovery/))
     .start();
 
   // const logStream = await container.logs();


### PR DESCRIPTION
Closes #386