### PR TITLE
feat(nice-grpc-prometheus): add metrics customization

### DIFF
--- a/packages/nice-grpc-prometheus/README.md
+++ b/packages/nice-grpc-prometheus/README.md
@@ -89,3 +89,54 @@ Metrics that correspond to finished calls have extra label:
 
 [npm-image]: https://badge.fury.io/js/nice-grpc-prometheus.svg
 [npm-url]: https://badge.fury.io/js/nice-grpc-prometheus
+
+### Customization
+
+You can use your own metric instances. This can be useful for example if you
+want to use your own buckets in histograms.
+
+```ts
+import {createClientFactory} from 'nice-grpc';
+import {
+  labelNames,
+  prometheusClientMiddleware,
+  registry,
+} from 'nice-grpc-prometheus';
+import {Histogram} from 'prom-client';
+
+const clientHandlingSecondsMetric = new Histogram({
+  registers: [registry],
+  name: 'custom_grpc_client_handling_seconds',
+  help: 'Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.',
+  labelNames,
+  buckets: [0.1, 0.5, 1, 2, 3, 5, 10],
+});
+
+const clientFactory = createClientFactory()
+  .use(prometheusClientMiddleware({clientHandlingSecondsMetric}))
+  .use(/* ... other middleware */);
+```
+
+Client middleware options:
+
+```ts
+{
+  clientStartedMetric?: Counter;
+  clientHandledMetric?: Counter;
+  clientStreamMsgReceivedMetric?: Counter;
+  clientStreamMsgSentMetric?: Counter;
+  clientHandlingSecondsMetric?: Histogram;
+}
+```
+
+Server middleware options:
+
+```ts
+{
+  serverStartedMetric?: Counter;
+  serverHandledMetric?: Counter;
+  serverStreamMsgReceivedMetric?: Counter;
+  serverStreamMsgSentMetric?: Counter;
+  serverHandlingSecondsMetric?: Histogram;
+}
+```

--- a/packages/nice-grpc-prometheus/README.md
+++ b/packages/nice-grpc-prometheus/README.md
@@ -98,17 +98,18 @@ want to use your own buckets in histograms.
 ```ts
 import {createClientFactory} from 'nice-grpc';
 import {
-  labelNames,
+  labelNamesWithCode,
   prometheusClientMiddleware,
-  registry,
 } from 'nice-grpc-prometheus';
-import {Histogram} from 'prom-client';
+import {Histogram, Registry} from 'prom-client';
+
+const registry = new Registry();
 
 const clientHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'custom_grpc_client_handling_seconds',
   help: 'Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.',
-  labelNames,
+  labelNames: labelNamesWithCode,
   buckets: [0.1, 0.5, 1, 2, 3, 5, 10],
 });
 
@@ -117,15 +118,19 @@ const clientFactory = createClientFactory()
   .use(/* ... other middleware */);
 ```
 
+Don't forget
+[to merge new registry with the global registry](https://github.com/siimon/prom-client#multiple-registries)
+or use default registry instead.
+
 Client middleware options:
 
 ```ts
 {
-  clientStartedMetric?: Counter;
-  clientHandledMetric?: Counter;
-  clientStreamMsgReceivedMetric?: Counter;
-  clientStreamMsgSentMetric?: Counter;
-  clientHandlingSecondsMetric?: Histogram;
+  clientStartedMetric?: Counter; // labelNames: labelNames
+  clientHandledMetric?: Counter; // labelNames: labelNamesWithCode
+  clientStreamMsgReceivedMetric?: Counter; // labelNames: labelNames
+  clientStreamMsgSentMetric?: Counter; // labelNames: labelNames
+  clientHandlingSecondsMetric?: Histogram; // labelNames: labelNamesWithCode
 }
 ```
 
@@ -133,10 +138,13 @@ Server middleware options:
 
 ```ts
 {
-  serverStartedMetric?: Counter;
-  serverHandledMetric?: Counter;
-  serverStreamMsgReceivedMetric?: Counter;
-  serverStreamMsgSentMetric?: Counter;
-  serverHandlingSecondsMetric?: Histogram;
+  serverStartedMetric?: Counter; // labelNames: labelNames
+  serverHandledMetric?: Counter; // labelNames: labelNamesWithCode
+  serverStreamMsgReceivedMetric?: Counter; // labelNames: labelNames
+  serverStreamMsgSentMetric?: Counter; // labelNames: labelNames
+  serverHandlingSecondsMetric?: Histogram; // labelNames: labelNamesWithCode
 }
 ```
+
+**Caution:** Use the labelNames specified in the comment. Using incorrect
+labelNames may cause errors now or in the future.

--- a/packages/nice-grpc-prometheus/src/__tests__/customMetrics.ts
+++ b/packages/nice-grpc-prometheus/src/__tests__/customMetrics.ts
@@ -1,0 +1,276 @@
+import {
+  createChannel,
+  createClientFactory,
+  createServer,
+  ServerError,
+  Status,
+} from 'nice-grpc';
+import {Counter, Histogram, Registry} from 'prom-client';
+import {
+  prometheusClientMiddleware,
+  prometheusServerMiddleware,
+  labelNames,
+} from '..';
+import {TestDefinition} from '../../fixtures/test';
+import {dumpMetrics} from './utils/dumpMetrics';
+import {throwUnimplemented} from './utils/throwUnimplemented';
+
+const registry = new Registry();
+
+const serverStartedMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_server_started_total',
+  help: 'Custom total number of RPCs started on the server.',
+  labelNames,
+});
+
+const serverHandledMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_server_handled_total',
+  help: 'Custom total number of RPCs completed on the server, regardless of success or failure.',
+  labelNames,
+});
+
+const serverStreamMsgReceivedMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_server_msg_received_total',
+  help: 'Custom total number of RPC stream messages received by the server.',
+  labelNames,
+});
+
+const serverStreamMsgSentMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_server_msg_sent_total',
+  help: 'Custom total number of gRPC stream messages sent by the server.',
+  labelNames,
+});
+
+const serverHandlingSecondsMetric = new Histogram({
+  registers: [registry],
+  name: 'custom_grpc_server_handling_seconds',
+  help: 'Custom histogram of response latency (seconds) of gRPC that had been application-level handled by the server.',
+  labelNames,
+  buckets: [0.1, 0.5, 1],
+});
+
+const clientStartedMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_client_started_total',
+  help: 'Custom total number of RPCs started on the client.',
+  labelNames,
+});
+
+const clientHandledMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_client_handled_total',
+  help: 'Custom total number of RPCs completed on the client, regardless of success or failure.',
+  labelNames,
+});
+
+const clientStreamMsgReceivedMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_client_msg_received_total',
+  help: 'Custom total number of RPC stream messages received by the client.',
+  labelNames,
+});
+
+const clientStreamMsgSentMetric = new Counter({
+  registers: [registry],
+  name: 'custom_grpc_client_msg_sent_total',
+  help: 'Custom total number of gRPC stream messages sent by the client.',
+  labelNames,
+});
+
+const clientHandlingSecondsMetric = new Histogram({
+  registers: [registry],
+  name: 'custom_grpc_client_handling_seconds',
+  help: 'Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.',
+  labelNames,
+  buckets: [0.1, 0.5, 1],
+});
+
+beforeEach(() => {
+  registry.resetMetrics();
+});
+
+test('basic', async () => {
+  const server = createServer().use(
+    prometheusServerMiddleware({
+      serverStartedMetric,
+      serverHandledMetric,
+      serverStreamMsgReceivedMetric,
+      serverStreamMsgSentMetric,
+      serverHandlingSecondsMetric,
+    }),
+  );
+
+  server.add(TestDefinition, {
+    async testUnary() {
+      return {};
+    },
+    testServerStream: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const port = await server.listen('localhost:0');
+
+  const channel = createChannel(`localhost:${port}`);
+  const client = createClientFactory()
+    .use(
+      prometheusClientMiddleware({
+        clientStartedMetric,
+        clientHandledMetric,
+        clientStreamMsgReceivedMetric,
+        clientStreamMsgSentMetric,
+        clientHandlingSecondsMetric,
+      }),
+    )
+    .create(TestDefinition, channel);
+
+  await client.testUnary({});
+
+  expect(await dumpMetrics(registry)).toMatchInlineSnapshot(`
+    "# HELP custom_grpc_server_started_total Custom total number of RPCs started on the server.
+    # TYPE custom_grpc_server_started_total counter
+    custom_grpc_server_started_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary"} 1
+
+    # HELP custom_grpc_server_handled_total Custom total number of RPCs completed on the server, regardless of success or failure.
+    # TYPE custom_grpc_server_handled_total counter
+    custom_grpc_server_handled_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} 1
+
+    # HELP custom_grpc_server_msg_received_total Custom total number of RPC stream messages received by the server.
+    # TYPE custom_grpc_server_msg_received_total counter
+
+    # HELP custom_grpc_server_msg_sent_total Custom total number of gRPC stream messages sent by the server.
+    # TYPE custom_grpc_server_msg_sent_total counter
+
+    # HELP custom_grpc_server_handling_seconds Custom histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
+    # TYPE custom_grpc_server_handling_seconds histogram
+    custom_grpc_server_handling_seconds_bucket{le="0.1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="0.5",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="+Inf",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_server_handling_seconds_sum{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_server_handling_seconds_count{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} 1
+
+    # HELP custom_grpc_client_started_total Custom total number of RPCs started on the client.
+    # TYPE custom_grpc_client_started_total counter
+    custom_grpc_client_started_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary"} 1
+
+    # HELP custom_grpc_client_handled_total Custom total number of RPCs completed on the client, regardless of success or failure.
+    # TYPE custom_grpc_client_handled_total counter
+    custom_grpc_client_handled_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} 1
+
+    # HELP custom_grpc_client_msg_received_total Custom total number of RPC stream messages received by the client.
+    # TYPE custom_grpc_client_msg_received_total counter
+
+    # HELP custom_grpc_client_msg_sent_total Custom total number of gRPC stream messages sent by the client.
+    # TYPE custom_grpc_client_msg_sent_total counter
+
+    # HELP custom_grpc_client_handling_seconds Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.
+    # TYPE custom_grpc_client_handling_seconds histogram
+    custom_grpc_client_handling_seconds_bucket{le="0.1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="0.5",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="+Inf",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_client_handling_seconds_sum{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} <num>
+    custom_grpc_client_handling_seconds_count{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="OK"} 1
+    "
+  `);
+
+  channel.close();
+
+  await server.shutdown();
+});
+
+test('error', async () => {
+  const server = createServer().use(
+    prometheusServerMiddleware({
+      serverStartedMetric,
+      serverHandledMetric,
+      serverStreamMsgReceivedMetric,
+      serverStreamMsgSentMetric,
+      serverHandlingSecondsMetric,
+    }),
+  );
+
+  server.add(TestDefinition, {
+    async testUnary() {
+      throw new ServerError(Status.NOT_FOUND, 'test error message');
+    },
+    testServerStream: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const port = await server.listen('localhost:0');
+
+  const channel = createChannel(`localhost:${port}`);
+  const client = createClientFactory()
+    .use(
+      prometheusClientMiddleware({
+        clientStartedMetric,
+        clientHandledMetric,
+        clientStreamMsgReceivedMetric,
+        clientStreamMsgSentMetric,
+        clientHandlingSecondsMetric,
+      }),
+    )
+    .create(TestDefinition, channel);
+
+  await client.testUnary({}).catch(() => {});
+
+  expect(await dumpMetrics(registry)).toMatchInlineSnapshot(`
+    "# HELP custom_grpc_server_started_total Custom total number of RPCs started on the server.
+    # TYPE custom_grpc_server_started_total counter
+    custom_grpc_server_started_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary"} 1
+
+    # HELP custom_grpc_server_handled_total Custom total number of RPCs completed on the server, regardless of success or failure.
+    # TYPE custom_grpc_server_handled_total counter
+    custom_grpc_server_handled_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} 1
+
+    # HELP custom_grpc_server_msg_received_total Custom total number of RPC stream messages received by the server.
+    # TYPE custom_grpc_server_msg_received_total counter
+
+    # HELP custom_grpc_server_msg_sent_total Custom total number of gRPC stream messages sent by the server.
+    # TYPE custom_grpc_server_msg_sent_total counter
+
+    # HELP custom_grpc_server_handling_seconds Custom histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
+    # TYPE custom_grpc_server_handling_seconds histogram
+    custom_grpc_server_handling_seconds_bucket{le="0.1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="0.5",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_server_handling_seconds_bucket{le="+Inf",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_server_handling_seconds_sum{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_server_handling_seconds_count{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} 1
+
+    # HELP custom_grpc_client_started_total Custom total number of RPCs started on the client.
+    # TYPE custom_grpc_client_started_total counter
+    custom_grpc_client_started_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary"} 1
+
+    # HELP custom_grpc_client_handled_total Custom total number of RPCs completed on the client, regardless of success or failure.
+    # TYPE custom_grpc_client_handled_total counter
+    custom_grpc_client_handled_total{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} 1
+
+    # HELP custom_grpc_client_msg_received_total Custom total number of RPC stream messages received by the client.
+    # TYPE custom_grpc_client_msg_received_total counter
+
+    # HELP custom_grpc_client_msg_sent_total Custom total number of gRPC stream messages sent by the client.
+    # TYPE custom_grpc_client_msg_sent_total counter
+
+    # HELP custom_grpc_client_handling_seconds Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.
+    # TYPE custom_grpc_client_handling_seconds histogram
+    custom_grpc_client_handling_seconds_bucket{le="0.1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="0.5",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="1",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_client_handling_seconds_bucket{le="+Inf",grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_client_handling_seconds_sum{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} <num>
+    custom_grpc_client_handling_seconds_count{grpc_type="unary",grpc_service="nice_grpc.test.Test",grpc_method="TestUnary",grpc_path="/nice_grpc.test.Test/TestUnary",grpc_code="NOT_FOUND"} 1
+    "
+  `);
+
+  channel.close();
+
+  await server.shutdown();
+});

--- a/packages/nice-grpc-prometheus/src/__tests__/customMetrics.ts
+++ b/packages/nice-grpc-prometheus/src/__tests__/customMetrics.ts
@@ -7,9 +7,10 @@ import {
 } from 'nice-grpc';
 import {Counter, Histogram, Registry} from 'prom-client';
 import {
+  labelNames,
+  labelNamesWithCode,
   prometheusClientMiddleware,
   prometheusServerMiddleware,
-  labelNames,
 } from '..';
 import {TestDefinition} from '../../fixtures/test';
 import {dumpMetrics} from './utils/dumpMetrics';
@@ -28,7 +29,7 @@ const serverHandledMetric = new Counter({
   registers: [registry],
   name: 'custom_grpc_server_handled_total',
   help: 'Custom total number of RPCs completed on the server, regardless of success or failure.',
-  labelNames,
+  labelNames: labelNamesWithCode,
 });
 
 const serverStreamMsgReceivedMetric = new Counter({
@@ -49,7 +50,7 @@ const serverHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'custom_grpc_server_handling_seconds',
   help: 'Custom histogram of response latency (seconds) of gRPC that had been application-level handled by the server.',
-  labelNames,
+  labelNames: labelNamesWithCode,
   buckets: [0.1, 0.5, 1],
 });
 
@@ -64,7 +65,7 @@ const clientHandledMetric = new Counter({
   registers: [registry],
   name: 'custom_grpc_client_handled_total',
   help: 'Custom total number of RPCs completed on the client, regardless of success or failure.',
-  labelNames,
+  labelNames: labelNamesWithCode,
 });
 
 const clientStreamMsgReceivedMetric = new Counter({
@@ -85,7 +86,7 @@ const clientHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'custom_grpc_client_handling_seconds',
   help: 'Custom histogram of response latency (seconds) of the gRPC until it is finished by the application.',
-  labelNames,
+  labelNames: labelNamesWithCode,
   buckets: [0.1, 0.5, 1],
 });
 

--- a/packages/nice-grpc-prometheus/src/client.ts
+++ b/packages/nice-grpc-prometheus/src/client.ts
@@ -19,35 +19,35 @@ import {
 } from './common';
 import {registry} from './registry';
 
-const clientStartedMetric = new Counter({
+const defaultClientStartedMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_started_total',
   help: 'Total number of RPCs started on the client.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const clientHandledMetric = new Counter({
+const defaultClientHandledMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_handled_total',
   help: 'Total number of RPCs completed on the client, regardless of success or failure.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
 });
 
-const clientStreamMsgReceivedMetric = new Counter({
+const defaultClientStreamMsgReceivedMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_msg_received_total',
   help: 'Total number of RPC stream messages received by the client.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const clientStreamMsgSentMetric = new Counter({
+const defaultClientStreamMsgSentMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_msg_sent_total',
   help: 'Total number of gRPC stream messages sent by the client.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const clientHandlingSecondsMetric = new Histogram({
+const defaultClientHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'grpc_client_handling_seconds',
   help: 'Histogram of response latency (seconds) of the gRPC until it is finished by the application.',
@@ -55,7 +55,56 @@ const clientHandlingSecondsMetric = new Histogram({
   buckets: latencySecondsBuckets,
 });
 
-export function prometheusClientMiddleware(): ClientMiddleware {
+type PrometheusClientMiddlewareOptions = {
+  clientStartedMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  clientHandledMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+    | typeof codeLabel
+  >;
+  clientStreamMsgReceivedMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  clientStreamMsgSentMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  clientHandlingSecondsMetric?: Histogram<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+    | typeof codeLabel
+  >;
+};
+
+export function prometheusClientMiddleware(
+  options?: PrometheusClientMiddlewareOptions,
+): ClientMiddleware {
+  const clientStartedMetric =
+    options?.clientStartedMetric || defaultClientStartedMetric;
+  const clientHandledMetric =
+    options?.clientHandledMetric || defaultClientHandledMetric;
+  const clientStreamMsgReceivedMetric =
+    options?.clientStreamMsgReceivedMetric ||
+    defaultClientStreamMsgReceivedMetric;
+  const clientStreamMsgSentMetric =
+    options?.clientStreamMsgSentMetric || defaultClientStreamMsgSentMetric;
+  const clientHandlingSecondsMetric =
+    options?.clientHandlingSecondsMetric || defaultClientHandlingSecondsMetric;
+
   return async function* prometheusClientMiddlewareGenerator<Request, Response>(
     call: ClientMiddlewareCall<Request, Response>,
     options: CallOptions,

--- a/packages/nice-grpc-prometheus/src/client.ts
+++ b/packages/nice-grpc-prometheus/src/client.ts
@@ -11,6 +11,8 @@ import {
   codeLabel,
   getLabels,
   incrementStreamMessagesCounter,
+  labelNames,
+  labelNamesWithCode,
   latencySecondsBuckets,
   methodLabel,
   pathLabel,
@@ -23,35 +25,35 @@ const defaultClientStartedMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_started_total',
   help: 'Total number of RPCs started on the client.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultClientHandledMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_handled_total',
   help: 'Total number of RPCs completed on the client, regardless of success or failure.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
+  labelNames: labelNamesWithCode,
 });
 
 const defaultClientStreamMsgReceivedMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_msg_received_total',
   help: 'Total number of RPC stream messages received by the client.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultClientStreamMsgSentMetric = new Counter({
   registers: [registry],
   name: 'grpc_client_msg_sent_total',
   help: 'Total number of gRPC stream messages sent by the client.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultClientHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'grpc_client_handling_seconds',
   help: 'Histogram of response latency (seconds) of the gRPC until it is finished by the application.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
+  labelNames: labelNamesWithCode,
   buckets: latencySecondsBuckets,
 });
 

--- a/packages/nice-grpc-prometheus/src/common.ts
+++ b/packages/nice-grpc-prometheus/src/common.ts
@@ -11,13 +11,8 @@ export const codeLabel = 'grpc_code';
  * 1ms, 4ms, 16ms, ..., ~1 hour in seconds
  */
 export const latencySecondsBuckets = exponentialBuckets(0.001, 4, 12);
-export const labelNames = [
-  typeLabel,
-  serviceLabel,
-  methodLabel,
-  pathLabel,
-  codeLabel,
-];
+export const labelNames = [typeLabel, serviceLabel, methodLabel, pathLabel];
+export const labelNamesWithCode = [...labelNames, codeLabel];
 
 export function getLabels(method: MethodDescriptor) {
   const callType = method.requestStream

--- a/packages/nice-grpc-prometheus/src/common.ts
+++ b/packages/nice-grpc-prometheus/src/common.ts
@@ -11,6 +11,13 @@ export const codeLabel = 'grpc_code';
  * 1ms, 4ms, 16ms, ..., ~1 hour in seconds
  */
 export const latencySecondsBuckets = exponentialBuckets(0.001, 4, 12);
+export const labelNames = [
+  typeLabel,
+  serviceLabel,
+  methodLabel,
+  pathLabel,
+  codeLabel,
+];
 
 export function getLabels(method: MethodDescriptor) {
   const callType = method.requestStream

--- a/packages/nice-grpc-prometheus/src/index.ts
+++ b/packages/nice-grpc-prometheus/src/index.ts
@@ -2,3 +2,5 @@ export {registry} from './registry';
 
 export {prometheusServerMiddleware} from './server';
 export {prometheusClientMiddleware} from './client';
+
+export {labelNames} from './common';

--- a/packages/nice-grpc-prometheus/src/index.ts
+++ b/packages/nice-grpc-prometheus/src/index.ts
@@ -3,4 +3,4 @@ export {registry} from './registry';
 export {prometheusServerMiddleware} from './server';
 export {prometheusClientMiddleware} from './client';
 
-export {labelNames} from './common';
+export {labelNames, labelNamesWithCode} from './common';

--- a/packages/nice-grpc-prometheus/src/server.ts
+++ b/packages/nice-grpc-prometheus/src/server.ts
@@ -11,6 +11,8 @@ import {
   codeLabel,
   getLabels,
   incrementStreamMessagesCounter,
+  labelNames,
+  labelNamesWithCode,
   latencySecondsBuckets,
   methodLabel,
   pathLabel,
@@ -23,35 +25,35 @@ const defaultStartedMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_started_total',
   help: 'Total number of RPCs started on the server.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultHandledMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_handled_total',
   help: 'Total number of RPCs completed on the server, regardless of success or failure.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
+  labelNames: labelNamesWithCode,
 });
 
 const defaultStreamMsgReceivedMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_msg_received_total',
   help: 'Total number of RPC stream messages received by the server.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultStreamMsgSentMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_msg_sent_total',
   help: 'Total number of gRPC stream messages sent by the server.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
+  labelNames,
 });
 
 const defaultHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'grpc_server_handling_seconds',
   help: 'Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.',
-  labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
+  labelNames: labelNamesWithCode,
   buckets: latencySecondsBuckets,
 });
 

--- a/packages/nice-grpc-prometheus/src/server.ts
+++ b/packages/nice-grpc-prometheus/src/server.ts
@@ -19,35 +19,35 @@ import {
 } from './common';
 import {registry} from './registry';
 
-const serverStartedMetric = new Counter({
+const defaultStartedMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_started_total',
   help: 'Total number of RPCs started on the server.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const serverHandledMetric = new Counter({
+const defaultHandledMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_handled_total',
   help: 'Total number of RPCs completed on the server, regardless of success or failure.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel, codeLabel],
 });
 
-const serverStreamMsgReceivedMetric = new Counter({
+const defaultStreamMsgReceivedMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_msg_received_total',
   help: 'Total number of RPC stream messages received by the server.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const serverStreamMsgSentMetric = new Counter({
+const defaultStreamMsgSentMetric = new Counter({
   registers: [registry],
   name: 'grpc_server_msg_sent_total',
   help: 'Total number of gRPC stream messages sent by the server.',
   labelNames: [typeLabel, serviceLabel, methodLabel, pathLabel],
 });
 
-const serverHandlingSecondsMetric = new Histogram({
+const defaultHandlingSecondsMetric = new Histogram({
   registers: [registry],
   name: 'grpc_server_handling_seconds',
   help: 'Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.',
@@ -55,7 +55,55 @@ const serverHandlingSecondsMetric = new Histogram({
   buckets: latencySecondsBuckets,
 });
 
-export function prometheusServerMiddleware(): ServerMiddleware {
+type PrometheusServerMiddlewareOptions = {
+  serverStartedMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  serverHandledMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+    | typeof codeLabel
+  >;
+  serverStreamMsgReceivedMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  serverStreamMsgSentMetric?: Counter<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+  >;
+  serverHandlingSecondsMetric?: Histogram<
+    | typeof typeLabel
+    | typeof serviceLabel
+    | typeof methodLabel
+    | typeof pathLabel
+    | typeof codeLabel
+  >;
+};
+
+export function prometheusServerMiddleware(
+  options?: PrometheusServerMiddlewareOptions,
+): ServerMiddleware {
+  const serverStartedMetric =
+    options?.serverStartedMetric || defaultStartedMetric;
+  const serverHandledMetric =
+    options?.serverHandledMetric || defaultHandledMetric;
+  const serverStreamMsgReceivedMetric =
+    options?.serverStreamMsgReceivedMetric || defaultStreamMsgReceivedMetric;
+  const serverStreamMsgSentMetric =
+    options?.serverStreamMsgSentMetric || defaultStreamMsgSentMetric;
+  const serverHandlingSecondsMetric =
+    options?.serverHandlingSecondsMetric || defaultHandlingSecondsMetric;
+
   return async function* prometheusServerMiddlewareGenerator<Request, Response>(
     call: ServerMiddlewareCall<Request, Response>,
     context: CallContext,


### PR DESCRIPTION
Hi!

I've found that the default buckets for histograms are not always suitable, and it would be useful to be able to customize them.

In looking for a way to change this I came to the conclusion that the most versatile and flexible way is to allow all metrics to be overridden.