### PR TITLE
Add example to docs for extending a client Type with CallOptions

### DIFF
--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -994,6 +994,15 @@ const client2 = clientFactory.use(middlewareC).create(Service2, channel2);
 In the above example, `Service1` client gets `middlewareA` and `middlewareB`,
 and `Service2` client gets `middlewareA` and `middlewareC`.
 
+Type augmentation to `Client` CallOptions is done automatically by adding a middleware, but can also be done by passing a generic. This code example shows how to correctly annotate client type given that middleware has type `ClientMiddleware<{callOption?: number}>`.
+
+```ts
+let client: ExampleServiceClient<{callOption?: number}>;
+client = createClientFactory()
+  .use(middleware)
+  .create(ExampleService, channel);
+```
+
 ##### Example: Logging
 
 Log all calls:


### PR DESCRIPTION
relates to #424

I totally missed how `CallOptions` can be added to a client type when trying to create my own middleware. It's pretty obvious in hindsight but I thought this example might help others from missing this in the future. 