### PR TITLE
fix(nice-grpc-error-details): add long to dependencies

### DIFF
--- a/packages/nice-grpc-error-details/package.json
+++ b/packages/nice-grpc-error-details/package.json
@@ -29,10 +29,8 @@
     "ts-proto": "^1.112.0"
   },
   "dependencies": {
+    "long": "^5.2.3",
     "nice-grpc-common": "^2.0.2",
     "protobufjs": "^7.1.2"
-  },
-  "peerDependencies": {
-    "long": ">=4"
   }
 }

--- a/packages/nice-grpc-error-details/package.json
+++ b/packages/nice-grpc-error-details/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "nice-grpc-common": "^2.0.2",
     "protobufjs": "^7.1.2"
+  },
+  "peerDependencies": {
+    "long": ">=4"
   }
 }


### PR DESCRIPTION
The `nice-grpc-error-details` pacakge requires `long` to work: https://www.runpkg.com/?nice-grpc-error-details@0.2.1/lib/proto/google/protobuf/duration.js#5

Add `long` to `peerDependencies`, so pnpm can install it into a correct folder. 