### PR TITLE
Skip deadline when signal is already aborted

### DIFF
--- a/packages/nice-grpc-client-middleware-deadline/src/index.ts
+++ b/packages/nice-grpc-client-middleware-deadline/src/index.ts
@@ -18,7 +18,7 @@ export type DeadlineOptions = {
  */
 export const deadlineMiddleware: ClientMiddleware<DeadlineOptions> =
   async function* deadlineMiddleware(call, options) {
-    if (options.deadline == null) {
+    if (options.deadline == null || options.signal?.aborted) {
       return yield* call.next(call.request, options);
     }
 


### PR DESCRIPTION
The deadline middleware replaces the original signal with a new one and attaches listeners for the `abort` event. This works for signals that are not aborted yet but if a signal is already aborted before starting the gRPC call the deadline middleware would still make the request because it did not receive the `abort` event.

This change skips the deadline middleware completely for calls with an aborted signal. The `nice-grpc` library will handle the aborted signal and abort the call correctly. 