### PR TITLE
chore(ci): disable --since for test runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,10 +111,10 @@ jobs:
           path: '**/node_modules'
           key: modules-${{ runner.os }}-20.x-${{ hashFiles('yarn.lock') }}
       - run: yarn --frozen-lockfile
-      - run: yarn build
-      - run: yarn lerna run test:local-browser-headless --scope nice-grpc-web
         env:
           CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
+      - run: yarn build
+      - run: yarn lerna run test:local-browser-headless --scope nice-grpc-web
 
   # Empty job that finishes after all required jobs finish.
   # Needed to not have to specify every single required job in branch protection.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,8 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn lerna run test:local-browser-headless --scope nice-grpc-web
+        env:
+          CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
 
   # Empty job that finishes after all required jobs finish.
   # Needed to not have to specify every single required job in branch protection.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,6 @@ jobs:
           path: '**/node_modules'
           key: modules-${{ runner.os }}-20.x-${{ hashFiles('yarn.lock') }}
       - run: yarn --frozen-lockfile
-        env:
-          CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
       - run: yarn build
       - run: yarn lerna run test:local-browser-headless --scope nice-grpc-web
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,10 +48,7 @@ jobs:
       - run: yarn build --ignore nice-grpc-web
       - env:
           NODE_OPTIONS: ${{ matrix.environment.node-options }}
-        run:
-          yarn test --ignore nice-grpc-web --since ${{ github.ref ==
-          'refs/heads/master' && github.event.before || format('origin/{0}',
-          github.base_ref) }}
+        run: yarn test --ignore nice-grpc-web
 
   nice-grpc-web-nodejs:
     name: nice-grpc-web NodeJS
@@ -89,10 +86,7 @@ jobs:
       - run: yarn build
       - env:
           NODE_OPTIONS: ${{ matrix.environment.node-options }}
-        run:
-          yarn test --scope nice-grpc-web --since ${{ github.ref ==
-          'refs/heads/master' && github.event.before || format('origin/{0}',
-          github.base_ref) }}
+        run: yarn test --scope nice-grpc-web
 
   nice-grpc-web-browser:
     name: nice-grpc-web Browser
@@ -118,10 +112,7 @@ jobs:
           key: modules-${{ runner.os }}-20.x-${{ hashFiles('yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      - run:
-          yarn lerna run test:local-browser-headless --scope nice-grpc-web
-          --since ${{ github.ref == 'refs/heads/master' && github.event.before
-          || format('origin/{0}', github.base_ref) }}
+      - run: yarn lerna run test:local-browser-headless --scope nice-grpc-web
 
   # Empty job that finishes after all required jobs finish.
   # Needed to not have to specify every single required job in branch protection.


### PR DESCRIPTION
`lerna test` with [`--since`](https://lerna.js.org/docs/features/run-tasks#run-tasks-affected-by-a-pr) flag does not trigger tests when only `yarn.lock` has changed, without updating `package.json`. This makes tests unreliable for most Dependabot updates.