### PR TITLE
avoid server.start() deprecation warning

### DIFF
--- a/packages/nice-grpc/src/server/Server.ts
+++ b/packages/nice-grpc/src/server/Server.ts
@@ -235,8 +235,6 @@ function createServerWithMiddleware<CallContextExt = {}>(
         );
       });
 
-      server.start();
-
       return port;
     },
 


### PR DESCRIPTION
To reproduce, run `yarn test serverClass` in packages/nice-grpc
```
yarn run v1.22.22
$ jest serverClass
(node:28544) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/__tests__/serverClass.ts
```
The DeprecationWarning is from https://github.com/grpc/grpc-node/blob/3c9436be8eb3788173796d4c90d2abe036d0f798/packages/grpc-js/src/server.ts#L1156-L1159

