### PR TITLE
test(nice-grpc-web): force envoy to use ipv4

### DIFF
--- a/packages/nice-grpc-web/test-server/envoy-tls.yaml
+++ b/packages/nice-grpc-web/test-server/envoy-tls.yaml
@@ -72,6 +72,7 @@ static_resources:
     - name: backend
       connect_timeout: 0.25s
       type: logical_dns
+      dns_lookup_family: V4_ONLY
       lb_policy: round_robin
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/packages/nice-grpc-web/test-server/envoy.yaml
+++ b/packages/nice-grpc-web/test-server/envoy.yaml
@@ -61,6 +61,7 @@ static_resources:
     - name: backend
       connect_timeout: 0.25s
       type: logical_dns
+      dns_lookup_family: V4_ONLY
       lb_policy: round_robin
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:


### PR DESCRIPTION
Improves test compatibility