### PR TITLE
feat(nice-grpc-server-reflection): use v1 protobufs

### DIFF
--- a/packages/nice-grpc-server-reflection/package.json
+++ b/packages/nice-grpc-server-reflection/package.json
@@ -21,7 +21,7 @@
     "test": "jest",
     "build": "tsc -P tsconfig.build.json && rimraf lib/proto && cpr src/proto lib/proto",
     "prepublishOnly": "npm test && npm run clean && npm run build",
-    "prepare:proto": "mkdirp ./src/proto && grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./src/proto --grpc_out=grpc_js:./src/proto --ts_out=grpc_js:./src/proto -I ./proto proto/grpc/reflection/v1alpha/reflection.proto && grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto --descriptor_set_out=fixtures/test.protoset.bin --include_imports",
+    "prepare:proto": "mkdirp ./src/proto && grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./src/proto --grpc_out=grpc_js:./src/proto --ts_out=grpc_js:./src/proto -I ./proto proto/grpc/reflection/v1/reflection.proto && grpc_tools_node_protoc --ts_proto_out=./fixtures --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false,esModuleInterop=true -I fixtures fixtures/*.proto --descriptor_set_out=fixtures/test.protoset.bin --include_imports",
     "prepare": "npm run prepare:proto"
   },
   "author": "Daniel Lytkin <aikoven@deeplay.io>",

--- a/packages/nice-grpc-server-reflection/proto/grpc/reflection/v1/reflection.proto
+++ b/packages/nice-grpc-server-reflection/proto/grpc/reflection/v1/reflection.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 gRPC authors.
+// Copyright 2016 The gRPC Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Service exported by server reflection
+// Service exported by server reflection.  A more complete description of how
+// server reflection works can be found at
+// https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
+//
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
 
 syntax = "proto3";
 
-package grpc.reflection.v1alpha;
+package grpc.reflection.v1;
+
+option go_package = "google.golang.org/grpc/reflection/grpc_reflection_v1";
+option java_multiple_files = true;
+option java_package = "io.grpc.reflection.v1";
+option java_outer_classname = "ServerReflectionProto";
 
 service ServerReflection {
   // The reflection service is structured as a bidirectional stream, ensuring
@@ -72,21 +82,21 @@ message ExtensionRequest {
 message ServerReflectionResponse {
   string valid_host = 1;
   ServerReflectionRequest original_request = 2;
-  // The server set one of the following fields accroding to the message_request
+  // The server sets one of the following fields according to the message_request
   // in the request.
   oneof message_response {
     // This message is used to answer file_by_filename, file_containing_symbol,
-    // file_containing_extension requests with transitive dependencies. As
-    // the repeated label is not allowed in oneof fields, we use a
+    // file_containing_extension requests with transitive dependencies.
+    // As the repeated label is not allowed in oneof fields, we use a
     // FileDescriptorResponse message to encapsulate the repeated fields.
     // The reflection service is allowed to avoid sending FileDescriptorProtos
     // that were previously sent in response to earlier requests in the stream.
     FileDescriptorResponse file_descriptor_response = 4;
 
-    // This message is used to answer all_extension_numbers_of_type requst.
+    // This message is used to answer all_extension_numbers_of_type requests.
     ExtensionNumberResponse all_extension_numbers_response = 5;
 
-    // This message is used to answer list_services request.
+    // This message is used to answer list_services requests.
     ListServiceResponse list_services_response = 6;
 
     // This message is used when an error occurs.

--- a/packages/nice-grpc-server-reflection/src/index.test.ts
+++ b/packages/nice-grpc-server-reflection/src/index.test.ts
@@ -10,7 +10,7 @@ import {readFileSync} from 'fs';
 
 import {ServerReflection, ServerReflectionService} from '.';
 import {TestDefinition} from '../fixtures/test';
-import {ServerReflectionRequest} from './proto/grpc/reflection/v1alpha/reflection_pb';
+import {ServerReflectionRequest} from './proto/grpc/reflection/v1/reflection_pb';
 
 async function* arrayToIter<T>(requests: T[]): AsyncIterable<T> {
   for (const request of requests) {

--- a/packages/nice-grpc-server-reflection/src/index.ts
+++ b/packages/nice-grpc-server-reflection/src/index.ts
@@ -7,7 +7,7 @@ import {
   MethodDescriptorProto,
   ServiceDescriptorProto,
 } from 'google-protobuf/google/protobuf/descriptor_pb';
-import {IServerReflectionService} from './proto/grpc/reflection/v1alpha/reflection_grpc_pb';
+import {IServerReflectionService} from './proto/grpc/reflection/v1/reflection_grpc_pb';
 import {
   ErrorResponse,
   ExtensionNumberResponse,
@@ -16,9 +16,9 @@ import {
   ServerReflectionRequest,
   ServerReflectionResponse,
   ServiceResponse,
-} from './proto/grpc/reflection/v1alpha/reflection_pb';
+} from './proto/grpc/reflection/v1/reflection_pb';
 
-export {ServerReflectionService} from './proto/grpc/reflection/v1alpha/reflection_grpc_pb';
+export {ServerReflectionService} from './proto/grpc/reflection/v1/reflection_grpc_pb';
 
 export function ServerReflection(
   protoset: Uint8Array,


### PR DESCRIPTION
BREAKING CHANGE: server reflection is now exposed via `grpc.reflection.v1.ServerReflection` service instead of `grpc.reflection.v1alpha.ServerReflection`. Tools like grpcurl should handle this automatically.