### PR TITLE
Extend tests

### DIFF
--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "test": "jest",
+    "debug-test": "node --inspect --expose-gc ../../node_modules/jest/bin/jest.js --runInBand --logHeapUsage --testTimeout=1000000",
     "build": "tsc -P tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build && npm test",
     "prepare:proto:grpc-js": "mkdirp ./fixtures/grpc-js && grpc_tools_node_protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./fixtures/grpc-js --ts_out=grpc_js:./fixtures/grpc-js --grpc_out=grpc_js:./fixtures/grpc-js -I fixtures fixtures/*.proto",
@@ -33,10 +34,8 @@
   "license": "MIT",
   "devDependencies": {
     "@tsconfig/node14": "^14.1.0",
-    "@types/defer-promise": "^1.0.0",
     "@types/google-protobuf": "^3.7.4",
     "@types/node": "^18.0.0",
-    "defer-promise": "^2.0.1",
     "google-protobuf": "^3.14.0",
     "grpc-tools": "^1.12.4",
     "grpc_tools_node_protoc_ts": "^5.0.1",

--- a/packages/nice-grpc/src/__tests__/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverStreaming.ts
@@ -769,8 +769,6 @@ test('graceful server shutdown', async () => {
   expect(serverGeneratorFinalized).toBe(true);
 
   channel.close();
-
-  await server.shutdown();
 });
 
 test('force server shutdown', async () => {

--- a/packages/nice-grpc/src/__tests__/serverStreaming.ts
+++ b/packages/nice-grpc/src/__tests__/serverStreaming.ts
@@ -1,5 +1,4 @@
-import defer = require('defer-promise');
-import {forever, isAbortError} from 'abort-controller-x';
+import {delay, forever, isAbortError} from 'abort-controller-x';
 import {
   Metadata,
   ServerError,
@@ -11,24 +10,7 @@ import {
 import {TestService} from '../../fixtures/grpc-js/test_grpc_pb';
 import {TestRequest, TestResponse} from '../../fixtures/grpc-js/test_pb';
 import {throwUnimplemented} from './utils/throwUnimplemented';
-
-function waitForAbort(signal: AbortSignal, timeout: number | undefined = 1000) {
-  return new Promise<void>((resolve, reject) => {
-    const savedError = new Error('waitForAbort timeout'); // capture stack trace of where the timeout was created
-    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-    const resolverReference = () => {
-      clearTimeout(timeoutId);
-      resolve();
-    };
-    signal.addEventListener('abort', resolverReference);
-    if (timeout) {
-      timeoutId = setTimeout(() => {
-        signal.removeEventListener('abort', resolverReference);
-        reject(savedError);
-      }, timeout);
-    }
-  });
-}
+import {defer} from './utils/defer';
 
 /**
  * Tests that two streaming RPCs one after another work correctly. Specifically tests
@@ -39,6 +21,8 @@ test('back-to-back', async () => {
 
   const serverSignal1 = defer<AbortSignal>();
   const serverSignal2 = defer<AbortSignal>();
+  const serverGeneratorFinalized1 = defer<void>();
+  const serverGeneratorFinalized2 = defer<void>();
 
   let firstTimeOnly = true;
 
@@ -53,9 +37,17 @@ test('back-to-back', async () => {
         serverSignal2.resolve(context.signal);
       }
 
-      let count = first ? 100 : 200;
-      while (true) {
-        yield new TestResponse().setId(`${request.getId()}-${count++}`);
+      try {
+        let count = first ? 100 : 200;
+        while (true) {
+          yield new TestResponse().setId(`${request.getId()}-${count++}`);
+        }
+      } finally {
+        if (first) {
+          serverGeneratorFinalized1.resolve();
+        } else {
+          serverGeneratorFinalized2.resolve();
+        }
       }
     },
     testUnary: throwUnimplemented,
@@ -79,8 +71,9 @@ test('back-to-back', async () => {
       },
     }
   `);
-  const serverSig1 = await serverSignal1.promise;
+  const serverSig1 = await serverSignal1;
   expect(serverSig1.aborted).toBe(false);
+  expect(serverGeneratorFinalized1.isResolved).toBe(false);
 
   await expect(it1.next()).resolves.toMatchInlineSnapshot(`
     {
@@ -93,7 +86,8 @@ test('back-to-back', async () => {
 
   expect(serverSig1.aborted).toBe(false);
   await it1.return?.();
-  await waitForAbort(serverSig1);
+  await serverGeneratorFinalized1;
+  expect(serverSig1.aborted).toBe(true);
 
   const it2 = client
     .testServerStream(new TestRequest().setId('second'))
@@ -106,8 +100,9 @@ test('back-to-back', async () => {
       },
     }
   `);
-  const serverSig2 = await serverSignal2.promise;
+  const serverSig2 = await serverSignal2;
   expect(serverSig2.aborted).toBe(false);
+  expect(serverGeneratorFinalized2.isResolved).toBe(false);
 
   await expect(it2.next()).resolves.toMatchInlineSnapshot(`
     {
@@ -120,7 +115,8 @@ test('back-to-back', async () => {
 
   expect(serverSig2.aborted).toBe(false);
   await it2.return?.();
-  await waitForAbort(serverSig2);
+  await serverGeneratorFinalized2;
+  expect(serverSig2.aborted).toBe(true);
 
   channel.close();
   await server.shutdown();
@@ -136,6 +132,8 @@ test('interleaved', async () => {
 
   const serverSignal1 = defer<AbortSignal>();
   const serverSignal2 = defer<AbortSignal>();
+  const serverGeneratorFinalized1 = defer<void>();
+  const serverGeneratorFinalized2 = defer<void>();
 
   let firstTimeOnly = true;
 
@@ -150,9 +148,17 @@ test('interleaved', async () => {
         serverSignal2.resolve(context.signal);
       }
 
-      let count = first ? 100 : 200;
-      while (true) {
-        yield new TestResponse().setId(`${request.getId()}-${count++}`);
+      try {
+        let count = first ? 100 : 200;
+        while (true) {
+          yield new TestResponse().setId(`${request.getId()}-${count++}`);
+        }
+      } finally {
+        if (first) {
+          serverGeneratorFinalized1.resolve();
+        } else {
+          serverGeneratorFinalized2.resolve();
+        }
       }
     },
     testUnary: throwUnimplemented,
@@ -176,8 +182,9 @@ test('interleaved', async () => {
       },
     }
   `);
-  const serverSig1 = await serverSignal1.promise;
+  const serverSig1 = await serverSignal1;
   expect(serverSig1.aborted).toBe(false);
+  expect(serverGeneratorFinalized1.isResolved).toBe(false);
 
   await expect(it1.next()).resolves.toMatchInlineSnapshot(`
     {
@@ -208,9 +215,11 @@ test('interleaved', async () => {
     }
   `);
 
-  const serverSig2 = await serverSignal2.promise;
+  const serverSig2 = await serverSignal2;
   expect(serverSig1.aborted).toBe(false);
   expect(serverSig2.aborted).toBe(false);
+  expect(serverGeneratorFinalized1.isResolved).toBe(false);
+  expect(serverGeneratorFinalized2.isResolved).toBe(false);
   await expect(it1.next()).resolves.toMatchInlineSnapshot(`
     {
       "done": false,
@@ -229,8 +238,10 @@ test('interleaved', async () => {
   `);
 
   expect(serverSig1.aborted).toBe(false);
+  expect(serverGeneratorFinalized1.isResolved).toBe(false);
   await it1.return?.();
-  await waitForAbort(serverSig1);
+  await serverGeneratorFinalized1;
+  expect(serverSig1.aborted).toBe(true);
 
   await expect(it2.next()).resolves.toMatchInlineSnapshot(`
     {
@@ -242,8 +253,10 @@ test('interleaved', async () => {
   `);
 
   expect(serverSig2.aborted).toBe(false);
+  expect(serverGeneratorFinalized2.isResolved).toBe(false);
   await it2.return?.();
-  await waitForAbort(serverSig2);
+  await serverGeneratorFinalized2;
+  expect(serverSig2.aborted).toBe(true);
 
   channel.close();
   await server.shutdown();
@@ -312,7 +325,7 @@ test('metadata', async () => {
 
       context.sendHeader();
 
-      await responseDeferred.promise;
+      await responseDeferred;
 
       context.trailer.set('test', values);
       context.trailer.set('test-bin', binValues);
@@ -353,13 +366,13 @@ test('metadata', async () => {
     return responses;
   });
 
-  await expect(headerDeferred.promise.then(header => header.getAll('test')))
-    .resolves.toMatchInlineSnapshot(`
+  await expect(headerDeferred.then(header => header.getAll('test'))).resolves
+    .toMatchInlineSnapshot(`
     [
       "test-value-1, test-value-2",
     ]
   `);
-  await expect(headerDeferred.promise.then(header => header.getAll('test-bin')))
+  await expect(headerDeferred.then(header => header.getAll('test-bin')))
     .resolves.toMatchInlineSnapshot(`
     [
       {
@@ -381,15 +394,14 @@ test('metadata', async () => {
 
   await expect(promise).resolves.toMatchInlineSnapshot(`[]`);
 
-  await expect(trailerDeferred.promise.then(header => header.getAll('test')))
-    .resolves.toMatchInlineSnapshot(`
+  await expect(trailerDeferred.then(header => header.getAll('test'))).resolves
+    .toMatchInlineSnapshot(`
     [
       "test-value-1, test-value-2",
     ]
   `);
-  await expect(
-    trailerDeferred.promise.then(header => header.getAll('test-bin')),
-  ).resolves.toMatchInlineSnapshot(`
+  await expect(trailerDeferred.then(header => header.getAll('test-bin')))
+    .resolves.toMatchInlineSnapshot(`
     [
       {
         "data": [
@@ -455,19 +467,24 @@ test('implicit header sending', async () => {
   await server.shutdown();
 });
 
-test('error', async () => {
+test('server error', async () => {
   const server = createServer();
 
   let serverSignal: AbortSignal;
+  let serverGeneratorFinalized = false;
 
   server.add(TestService, {
     testUnary: throwUnimplemented,
     async *testServerStream(request: TestRequest, context) {
-      serverSignal = context.signal;
-      yield new TestResponse().setId(request.getId());
+      try {
+        serverSignal = context.signal;
+        yield new TestResponse().setId(request.getId());
 
-      context.trailer.set('test', 'test-value');
-      throw new ServerError(Status.ABORTED, 'test');
+        context.trailer.set('test', 'test-value');
+        throw new ServerError(Status.ABORTED, 'test');
+      } finally {
+        serverGeneratorFinalized = true;
+      }
     },
     testClientStream: throwUnimplemented,
     testBidiStream: throwUnimplemented,
@@ -511,6 +528,7 @@ test('error', async () => {
     ]
   `);
   expect(serverSignal!.aborted).toBe(false);
+  expect(serverGeneratorFinalized).toBe(true);
 
   expect(trailer?.getAll('test')).toMatchInlineSnapshot(`
     [
@@ -523,10 +541,11 @@ test('error', async () => {
   await server.shutdown();
 });
 
-test('cancel', async () => {
+test('client cancel', async () => {
   const server = createServer();
 
   const serverAbortDeferred = defer<void>();
+  let serverGeneratorFinalized = false;
 
   server.add(TestService, {
     testUnary: throwUnimplemented,
@@ -539,8 +558,9 @@ test('cancel', async () => {
         if (isAbortError(err)) {
           serverAbortDeferred.resolve();
         }
-
         throw err;
+      } finally {
+        serverGeneratorFinalized = true;
       }
     },
     testClientStream: throwUnimplemented,
@@ -584,7 +604,8 @@ test('cancel', async () => {
     ]
   `);
 
-  await serverAbortDeferred.promise;
+  await serverAbortDeferred;
+  expect(serverGeneratorFinalized).toBe(true);
 
   channel.close();
 
@@ -629,6 +650,7 @@ test('aborted iteration on client', async () => {
   const server = createServer();
 
   const serverAbortDeferred = defer<void>();
+  let serverGeneratorFinalized = false;
 
   server.add(TestService, {
     testUnary: throwUnimplemented,
@@ -643,6 +665,8 @@ test('aborted iteration on client', async () => {
         }
 
         throw err;
+      } finally {
+        serverGeneratorFinalized = true;
       }
     },
     testClientStream: throwUnimplemented,
@@ -683,7 +707,129 @@ test('aborted iteration on client', async () => {
     ]
   `);
 
-  await serverAbortDeferred.promise;
+  await serverAbortDeferred;
+  expect(serverGeneratorFinalized).toBe(true);
+
+  channel.close();
+
+  await server.shutdown();
+});
+
+test('graceful server shutdown', async () => {
+  const server = createServer();
+
+  let serverSignal: AbortSignal;
+  let serverGeneratorFinalized = false;
+
+  server.add(TestService, {
+    async *testServerStream(request: TestRequest, context) {
+      serverSignal = context.signal;
+
+      try {
+        yield new TestResponse().setId(`${request.getId()}-1`);
+        await delay(context.signal, 200);
+        yield new TestResponse().setId(`${request.getId()}-2`);
+      } finally {
+        serverGeneratorFinalized = true;
+      }
+    },
+    testUnary: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const port = await server.listen('127.0.0.1:0');
+
+  const channel = createChannel(`127.0.0.1:${port}`);
+  const client = createClient(TestService, channel);
+
+  const responses: any[] = [];
+  let shutdownPromise: Promise<void> | undefined;
+  for await (const response of client.testServerStream(
+    new TestRequest().setId('test'),
+  )) {
+    responses.push(response);
+    if (responses.length === 1) {
+      shutdownPromise = server.shutdown();
+    }
+  }
+
+  expect(responses).toMatchInlineSnapshot(`
+    [
+      nice_grpc.test.TestResponse {
+        "id": "test-1",
+      },
+      nice_grpc.test.TestResponse {
+        "id": "test-2",
+      },
+    ]
+  `);
+  await shutdownPromise;
+  expect(serverSignal!.aborted).toBe(false);
+  expect(serverGeneratorFinalized).toBe(true);
+
+  channel.close();
+
+  await server.shutdown();
+});
+
+test('force server shutdown', async () => {
+  const server = createServer();
+
+  let serverSignal: AbortSignal;
+  let serverGeneratorFinalized = defer<void>();
+
+  server.add(TestService, {
+    async *testServerStream(request: TestRequest, context) {
+      serverSignal = context.signal;
+
+      try {
+        yield new TestResponse().setId(`${request.getId()}-1`);
+        await delay(context.signal, 200);
+        yield new TestResponse().setId(`${request.getId()}-2`);
+      } finally {
+        serverGeneratorFinalized.resolve();
+      }
+    },
+    testUnary: throwUnimplemented,
+    testClientStream: throwUnimplemented,
+    testBidiStream: throwUnimplemented,
+  });
+
+  const port = await server.listen('127.0.0.1:0');
+
+  const channel = createChannel(`127.0.0.1:${port}`);
+  const client = createClient(TestService, channel);
+
+  const responses: any[] = [];
+
+  try {
+    for await (const response of client.testServerStream(
+      new TestRequest().setId('test'),
+    )) {
+      responses.push(response);
+      if (responses.length === 1) {
+        server.forceShutdown();
+      }
+    }
+  } catch (error) {
+    responses.push({type: 'error', error});
+  }
+
+  expect(responses).toMatchInlineSnapshot(`
+    [
+      nice_grpc.test.TestResponse {
+        "id": "test-1",
+      },
+      {
+        "error": [ClientError: /nice_grpc.test.Test/TestServerStream CANCELLED: Call cancelled],
+        "type": "error",
+      },
+    ]
+  `);
+
+  await serverGeneratorFinalized;
+  expect(serverSignal!.aborted).toBe(true);
 
   channel.close();
 

--- a/packages/nice-grpc/src/__tests__/utils/defer.ts
+++ b/packages/nice-grpc/src/__tests__/utils/defer.ts
@@ -1,0 +1,35 @@
+export interface Deferred<T> extends Promise<T> {
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+  isResolved: boolean;
+  isRejected: boolean;
+  isSettled: boolean;
+}
+
+export function defer<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+
+  const deferred = promise as Deferred<T>;
+  deferred.resolve = resolve;
+  deferred.reject = reject;
+  deferred.isResolved = false;
+  deferred.isRejected = false;
+  deferred.isSettled = false;
+  deferred.then(
+    () => {
+      deferred.isResolved = true;
+      deferred.isSettled = true;
+    },
+    () => {
+      deferred.isRejected = true;
+      deferred.isSettled = true;
+    },
+  );
+
+  return deferred;
+}


### PR DESCRIPTION
For our application it was important that server methods are always properly aborted and finalised whenever the connection was closed in all (edge) cases, this to properly free up resources as soon as possible and avoid memory leaks.

To ensure this, a couple more tests and assertions were added in this PR. Good thing is, all (new) tests pass without any changes to the source code (Thanks for this great library!), so feel free to merge or ignore this PR as you like.