### PR TITLE
docs(nice-grpc): add waitForChannelReady to README

### DIFF
--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -794,6 +794,19 @@ createChannel('example.com:8080', ChannelCredentials.createSsl());
 If the port is omitted, it defaults to `80` for insecure connections, and `443`
 for secure connections.
 
+To wait for a channel to be ready before making calls, use
+`waitForChannelReady`. It is not required to call this function before making
+calls — they will connect automatically. This can be useful if you want to
+verify that the server is reachable at startup.
+
+```ts
+import {createChannel, waitForChannelReady} from 'nice-grpc';
+
+const channel = createChannel('localhost:8080');
+
+await waitForChannelReady(channel, new Date(Date.now() + 5000));
+```
+
 #### Metadata
 
 Client can send request metadata and receive response header and trailer:
@@ -994,13 +1007,14 @@ const client2 = clientFactory.use(middlewareC).create(Service2, channel2);
 In the above example, `Service1` client gets `middlewareA` and `middlewareB`,
 and `Service2` client gets `middlewareA` and `middlewareC`.
 
-Type augmentation to `Client` CallOptions is done automatically by adding a middleware, but can also be done by passing a generic. This code example shows how to correctly annotate client type given that middleware has type `ClientMiddleware<{callOption?: number}>`.
+Type augmentation to `Client` CallOptions is done automatically by adding a
+middleware, but can also be done by passing a generic. This code example shows
+how to correctly annotate client type given that middleware has type
+`ClientMiddleware<{callOption?: number}>`.
 
 ```ts
 let client: ExampleServiceClient<{callOption?: number}>;
-client = createClientFactory()
-  .use(middleware)
-  .create(ExampleService, channel);
+client = createClientFactory().use(middleware).create(ExampleService, channel);
 ```
 
 ##### Example: Logging


### PR DESCRIPTION
## Summary
- Add documentation for `waitForChannelReady` function to the Channels section of nice-grpc README
- Include usage example with `createChannel` and a deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)