### PR TITLE
fix(nice-grpc): throw AbortError on cancelled client request stream

### DIFF
--- a/packages/nice-grpc/src/__tests__/readableToAsyncIterable.ts
+++ b/packages/nice-grpc/src/__tests__/readableToAsyncIterable.ts
@@ -1,0 +1,45 @@
+import {test, expect} from 'vitest';
+import {isAbortError} from 'abort-controller-x';
+import {Readable} from 'stream';
+import {readableToAsyncIterable} from '../utils/readableToAsyncIterable';
+
+test('throws AbortError with original error as cause when stream errors after signal aborted', async () => {
+  const ac = new AbortController();
+
+  const stream = new Readable({objectMode: true, read() {}});
+
+  const iterationPromise = (async () => {
+    for await (const _ of readableToAsyncIterable(stream as any, ac.signal)) {
+      // not expected to yield anything
+    }
+  })();
+
+  // Simulate: grpc-js emits 'cancelled' first (signal aborted), then 'error' on the stream
+  ac.abort();
+  const grpcError = Object.assign(new Error('The operation was cancelled'), {
+    code: 1,
+  });
+  stream.destroy(grpcError);
+
+  await expect(iterationPromise).rejects.toSatisfy(isAbortError);
+
+  const thrown = await iterationPromise.catch(err => err);
+  expect(thrown.cause).toBe(grpcError);
+});
+
+test('still throws the original error when stream errors without signal being aborted', async () => {
+  const ac = new AbortController();
+
+  const stream = new Readable({objectMode: true, read() {}});
+
+  const iterationPromise = (async () => {
+    for await (const _ of readableToAsyncIterable(stream as any, ac.signal)) {
+      // not expected to yield anything
+    }
+  })();
+
+  const originalError = new Error('unexpected stream error');
+  stream.destroy(originalError);
+
+  await expect(iterationPromise).rejects.toBe(originalError);
+});

--- a/packages/nice-grpc/src/server/handleBidiStreamingCall.ts
+++ b/packages/nice-grpc/src/server/handleBidiStreamingCall.ts
@@ -59,7 +59,10 @@ export function createBidiStreamingMethodHandler<Request, Response>(
 
     Promise.resolve()
       .then(async () => {
-        const iterable = handler(readableToAsyncIterable(call), context);
+        const iterable = handler(
+          readableToAsyncIterable(call, context.signal),
+          context,
+        );
         const iterator = iterable[Symbol.asyncIterator]();
 
         try {

--- a/packages/nice-grpc/src/server/handleClientStreamingCall.ts
+++ b/packages/nice-grpc/src/server/handleClientStreamingCall.ts
@@ -58,7 +58,10 @@ export function createClientStreamingMethodHandler<Request, Response>(
 
     Promise.resolve()
       .then(async () => {
-        const iterable = handler(readableToAsyncIterable(call), context);
+        const iterable = handler(
+          readableToAsyncIterable(call, context.signal),
+          context,
+        );
         const iterator = iterable[Symbol.asyncIterator]();
 
         try {

--- a/packages/nice-grpc/src/utils/readableToAsyncIterable.ts
+++ b/packages/nice-grpc/src/utils/readableToAsyncIterable.ts
@@ -1,3 +1,4 @@
+import {AbortError} from 'abort-controller-x';
 import {ObjectReadable} from '@grpc/grpc-js/build/src/object-stream';
 
 type NodeInternalReadableState = {
@@ -42,6 +43,7 @@ function nodejsInternalsAccessible(obj: any): obj is NodeInternalReadableState {
  */
 export async function* readableToAsyncIterable<T>(
   stream: ObjectReadable<T>,
+  signal?: AbortSignal,
 ): AsyncIterable<T> {
   let callback = nop;
 
@@ -85,6 +87,11 @@ export async function* readableToAsyncIterable<T>(
     if (chunk !== null) {
       yield chunk;
     } else if (errorEmitted) {
+      if (signal?.aborted) {
+        const abortError = new AbortError();
+        (abortError as any).cause = error;
+        throw abortError;
+      }
       throw error;
     } else if (endEmitted) {
       break;


### PR DESCRIPTION
When a client cancels a bidi/client-streaming call (RST_STREAM, disconnect,
server shutdown), grpc-js emits an 'error' on the readable stream.
readableToAsyncIterable was re-throwing this raw StatusObject, forcing
consumers to suppress grpc-internal errors manually.

Since createCallContext already aborts context.signal before the stream
error arrives, use signal.aborted as the discriminator: when the stream
errors after signal is aborted, throw AbortError (with the original grpc
error preserved as .cause) instead of the raw StatusObject. This aligns
with the abort-controller-x conventions used throughout the codebase and
gives handlers a clean three-way distinction:

- Normal iterator completion: client half-closed, all messages received
- AbortError (isAbortError): expected cancellation (client or server)
- Any other error: unexpected / unrecoverable (bug, resource exhaustion)

Changes:
- readableToAsyncIterable: accept optional AbortSignal; on errorEmitted
  with signal.aborted, throw AbortError with .cause = original error
- handleBidiStreamingCall: pass context.signal to readableToAsyncIterable
- handleClientStreamingCall: pass context.signal to readableToAsyncIterable