### PR TITLE
chore: add npm metadata links

### DIFF
--- a/packages/nice-grpc-client-middleware-deadline/package.json
+++ b/packages/nice-grpc-client-middleware-deadline/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-client-middleware-deadline",
   "version": "2.0.19",
   "description": "Deadline client middleware for nice-grpc",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-client-middleware-deadline"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-client-middleware-deadline#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-client-middleware-devtools/package.json
+++ b/packages/nice-grpc-client-middleware-devtools/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-client-middleware-devtools",
   "version": "1.0.11",
   "description": "Client middleware for nice-grpc to work with grpc-web-devtools https://github.com/SafetyCulture/grpc-web-devtools",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-client-middleware-devtools"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-client-middleware-devtools#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-client-middleware-retry/package.json
+++ b/packages/nice-grpc-client-middleware-retry/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-client-middleware-retry",
   "version": "3.1.15",
   "description": "Retry client middleware for nice-grpc",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-client-middleware-retry"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-client-middleware-retry#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-common/package.json
+++ b/packages/nice-grpc-common/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-common",
   "version": "2.0.3",
   "description": "Common stuff for nice-grpc and nice-grpc-web",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-common"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-common#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-error-details/package.json
+++ b/packages/nice-grpc-error-details/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-error-details",
   "version": "0.2.14",
   "description": "gRPC rich error model implementation for nice-grpc",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-error-details"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-error-details#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-opentelemetry/package.json
+++ b/packages/nice-grpc-opentelemetry/package.json
@@ -8,7 +8,15 @@
     "opentelemetry",
     "tracing"
   ],
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-opentelemetry"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-opentelemetry#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-prometheus/package.json
+++ b/packages/nice-grpc-prometheus/package.json
@@ -9,7 +9,15 @@
     "monitoring",
     "metrics"
   ],
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-prometheus"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-prometheus#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-server-health/package.json
+++ b/packages/nice-grpc-server-health/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-server-health",
   "version": "2.0.19",
   "description": "gRPC health checking protocol implementation for nice-grpc",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-server-health"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-server-health#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-server-middleware-terminator/package.json
+++ b/packages/nice-grpc-server-middleware-terminator/package.json
@@ -2,7 +2,15 @@
   "name": "nice-grpc-server-middleware-terminator",
   "version": "2.0.18",
   "description": "Server middleware for nice-grpc to terminate long-running calls on shutdown",
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-server-middleware-terminator"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-server-middleware-terminator#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-server-reflection/package.json
+++ b/packages/nice-grpc-server-reflection/package.json
@@ -7,7 +7,15 @@
     "nice-grpc",
     "server-reflection"
   ],
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-server-reflection"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-server-reflection#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc-web/package.json
+++ b/packages/nice-grpc-web/package.json
@@ -11,7 +11,15 @@
     "abort-signal",
     "typescript"
   ],
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc-web"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-web#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/nice-grpc/package.json
+++ b/packages/nice-grpc/package.json
@@ -10,7 +10,15 @@
     "abort-signal",
     "typescript"
   ],
-  "repository": "deeplay-io/nice-grpc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeplay-io/nice-grpc.git",
+    "directory": "packages/nice-grpc"
+  },
+  "homepage": "https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc#readme",
+  "bugs": {
+    "url": "https://github.com/deeplay-io/nice-grpc/issues"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
﻿## Summary

This updates the published package metadata for each workspace package:

- expands the shorthand `repository` value into an npm repository object
- adds the package-specific `repository.directory`
- adds a package README `homepage`
- adds the shared GitHub issue tracker as `bugs.url`

No runtime code, dependencies, generated files, or package entry points are changed.

## Verification

- manifest check across all 12 package manifests
- `git diff --cached --check`
- `.\node_modules\.bin\prettier.cmd --check "packages/*/package.json"`
- `npm pack --dry-run --json --ignore-scripts` for each package under `packages/*`
- WSL Ubuntu 26.04:
  - `npm pkg get repository homepage bugs --json` in `packages/nice-grpc`
  - `npm pack --dry-run --json --ignore-scripts` for each package under `packages/*`

I also installed dependencies with `corepack yarn install --frozen-lockfile --ignore-scripts`. A full Windows `yarn build` was not used as a pass/fail signal for this metadata-only change because the scriptless install leaves generated proto files absent, and the existing `nice-grpc-web` build command uses shell quoting that does not run under `cmd.exe`.
