### PR TITLE
fix(nice-grpc): time out connection attempts that get no response

### DIFF
--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -816,13 +816,20 @@ such a timeout, a network path that accepts TCP connections but never responds
 leaves the channel stuck in `CONNECTING` forever, and calls made without a
 deadline hang indefinitely.
 
-The timeout can be changed, or disabled by setting it to `0`:
+The timeout can be changed via the `grpc.min_reconnect_backoff_ms` channel
+option, or disabled by setting it to `0`:
 
 ```ts
 createChannel('example.com:8080', undefined, {
-  'grpc-node.connect_timeout_ms': 10_000,
+  'grpc.min_reconnect_backoff_ms': 10_000,
 });
 ```
+
+Despite its name, this is the channel argument that other gRPC implementations
+use for `MIN_CONNECT_TIMEOUT`: C-core parses
+[`GRPC_ARG_MIN_RECONNECT_BACKOFF_MS`](https://github.com/grpc/grpc/blob/master/include/grpc/impl/channel_arg_names.h)
+into the deadline it gives a connection attempt, and grpc-go has the equivalent
+`minConnectTimeout`. grpc-js itself does not read this option.
 
 #### Metadata
 

--- a/packages/nice-grpc/README.md
+++ b/packages/nice-grpc/README.md
@@ -805,6 +805,25 @@ const channel = createChannel('localhost:8080');
 await waitForChannelReady(channel, new Date(Date.now() + 5000));
 ```
 
+##### Connection attempt timeout
+
+A connection attempt that gets no response is aborted after 20 seconds, matching
+`MIN_CONNECT_TIMEOUT` from the
+[gRPC connection backoff spec](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md),
+after which the channel retries it with backoff. This works around
+[grpc/grpc-node#2785](https://github.com/grpc/grpc-node/issues/2785): without
+such a timeout, a network path that accepts TCP connections but never responds
+leaves the channel stuck in `CONNECTING` forever, and calls made without a
+deadline hang indefinitely.
+
+The timeout can be changed, or disabled by setting it to `0`:
+
+```ts
+createChannel('example.com:8080', undefined, {
+  'grpc-node.connect_timeout_ms': 10_000,
+});
+```
+
 #### Metadata
 
 Client can send request metadata and receive response header and trailer:

--- a/packages/nice-grpc/src/__tests__/connectTimeout.ts
+++ b/packages/nice-grpc/src/__tests__/connectTimeout.ts
@@ -1,0 +1,213 @@
+import * as net from 'net';
+import {test, expect} from 'vitest';
+import {Channel, ChannelOptions, connectivityState} from '@grpc/grpc-js';
+import {createChannel, createClient} from '..';
+import {TestDefinition} from '../../fixtures/ts-proto/test';
+import {defer} from './utils/defer';
+
+/**
+ * Shortened connection attempt timeout, so that the tests don't have to wait
+ * for the full `MIN_CONNECT_TIMEOUT` of 20 seconds.
+ */
+const connectTimeoutMs = 3000;
+
+/** Generous multiple of `connectTimeoutMs` to wait for the expected outcome. */
+const waitMs = 10_000;
+
+const channelOptions: ChannelOptions = {
+  'grpc-node.connect_timeout_ms': connectTimeoutMs,
+  // Keep backoff short, so that a retry, if any, happens within the test.
+  'grpc.initial_reconnect_backoff_ms': 100,
+  'grpc.max_reconnect_backoff_ms': 100,
+};
+
+/**
+ * Starts a TCP server that accepts connections but never sends anything,
+ * emulating a network path that is established at the TCP level but silently
+ * drops all data (a broken middlebox flow, a half-open path left after a NAT
+ * conntrack entry is dropped etc.).
+ *
+ * From the client's point of view the TCP handshake succeeds, but the server's
+ * HTTP/2 SETTINGS frame never arrives.
+ */
+async function startSilentServer() {
+  const sockets = new Set<net.Socket>();
+  let connectionCount = 0;
+
+  const server = net.createServer(socket => {
+    connectionCount += 1;
+    sockets.add(socket);
+    socket.on('data', () => {});
+    socket.on('error', () => {});
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  const listening = defer<void>();
+  server.listen(0, '127.0.0.1', () => listening.resolve());
+  await listening;
+
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    /** Total number of connections accepted. */
+    get connectionCount() {
+      return connectionCount;
+    },
+    /** Number of connections that are still open. */
+    get openConnectionCount() {
+      return sockets.size;
+    },
+    async close() {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+
+      const closed = defer<void>();
+      server.close(() => closed.resolve());
+      await closed;
+    },
+  };
+}
+
+function watchStateChange(
+  channel: Channel,
+  state: connectivityState,
+  timeoutMs: number,
+): Promise<boolean> {
+  const changed = defer<boolean>();
+
+  channel.watchConnectivityState(state, Date.now() + timeoutMs, err => {
+    changed.resolve(err == null);
+  });
+
+  return changed;
+}
+
+/**
+ * A connection attempt that completes at the TCP level but never receives the
+ * server's HTTP/2 SETTINGS frame must not hang forever.
+ *
+ * The gRPC connection backoff spec requires a connection attempt to be given at
+ * most `MIN_CONNECT_TIMEOUT` (20 seconds), after which it fails and the
+ * subchannel goes to TRANSIENT_FAILURE, from where backoff retries it:
+ * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+ *
+ * grpc-js has no such timeout: `Http2SubchannelConnector.createSession` awaits
+ * the `remoteSettings` event with no timer, so the returned promise never
+ * settles and the subchannel stays in CONNECTING indefinitely. Since backoff is
+ * only armed when a connection attempt *fails*, no retry is ever scheduled and
+ * the channel stays dead until it is recreated.
+ *
+ * https://github.com/grpc/grpc-node/issues/2785
+ */
+test('connection attempt to a silent path times out', async () => {
+  const server = await startSilentServer();
+
+  const channel = createChannel(`127.0.0.1:${server.port}`, undefined, {
+    ...channelOptions,
+    // Keepalive does not help here: it only applies to an established
+    // transport, and no transport is ever established.
+    'grpc.keepalive_time_ms': 1000,
+    'grpc.keepalive_timeout_ms': 1000,
+  });
+
+  try {
+    // Trigger connecting. The transition out of IDLE is asynchronous.
+    expect(channel.getConnectivityState(true)).toBe(connectivityState.IDLE);
+    expect(await watchStateChange(channel, connectivityState.IDLE, 1000)).toBe(
+      true,
+    );
+    expect(channel.getConnectivityState(false)).toBe(
+      connectivityState.CONNECTING,
+    );
+
+    const leftConnecting = await watchStateChange(
+      channel,
+      connectivityState.CONNECTING,
+      waitMs,
+    );
+
+    expect(
+      leftConnecting,
+      'channel stayed in CONNECTING: the connection attempt never timed out',
+    ).toBe(true);
+  } finally {
+    channel.close();
+    await server.close();
+  }
+});
+
+/**
+ * A call made over a channel whose connection attempt is hanging must fail
+ * rather than block forever, even when no deadline is set.
+ */
+test('call over a silent path fails instead of hanging', async () => {
+  const server = await startSilentServer();
+
+  const channel = createChannel(
+    `127.0.0.1:${server.port}`,
+    undefined,
+    channelOptions,
+  );
+  const client = createClient(TestDefinition, channel);
+
+  const timedOut = Symbol('timedOut');
+
+  try {
+    // No deadline: the call may only fail because the connection attempt
+    // failed, not because a deadline passed.
+    const result = await Promise.race([
+      client.testUnary({id: 'test'}).then(
+        () => 'resolved',
+        (err: unknown) => err,
+      ),
+      new Promise<typeof timedOut>(resolve =>
+        setTimeout(() => resolve(timedOut), waitMs).unref(),
+      ),
+    ]);
+
+    expect(
+      result,
+      'the call neither failed nor completed: it hung on a dead channel',
+    ).not.toBe(timedOut);
+    expect(result).toMatchObject({
+      message: expect.stringMatching(/UNAVAILABLE/),
+    });
+  } finally {
+    channel.close();
+    await server.close();
+  }
+});
+
+/**
+ * A timed out connection attempt must be torn down. Otherwise every retry
+ * leaves behind an established socket that the client will never use, and a
+ * channel reconnecting in a loop leaks a socket per attempt.
+ */
+test('timed out connection attempts do not leak sockets', async () => {
+  const server = await startSilentServer();
+
+  const channel = createChannel(`127.0.0.1:${server.port}`, undefined, {
+    ...channelOptions,
+    'grpc-node.connect_timeout_ms': 500,
+  });
+
+  try {
+    channel.getConnectivityState(true);
+
+    // Let the channel go through several connection attempts.
+    const deadline = Date.now() + 5000;
+
+    while (Date.now() < deadline) {
+      // Nudge the channel out of TRANSIENT_FAILURE / IDLE to keep it retrying.
+      channel.getConnectivityState(true);
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+
+    expect(server.connectionCount).toBeGreaterThan(2);
+    // At most the currently pending attempt may be open.
+    expect(server.openConnectionCount).toBeLessThanOrEqual(1);
+  } finally {
+    channel.close();
+    await server.close();
+  }
+});

--- a/packages/nice-grpc/src/__tests__/connectTimeout.ts
+++ b/packages/nice-grpc/src/__tests__/connectTimeout.ts
@@ -15,7 +15,7 @@ const connectTimeoutMs = 3000;
 const waitMs = 10_000;
 
 const channelOptions: ChannelOptions = {
-  'grpc-node.connect_timeout_ms': connectTimeoutMs,
+  'grpc.min_reconnect_backoff_ms': connectTimeoutMs,
   // Keep backoff short, so that a retry, if any, happens within the test.
   'grpc.initial_reconnect_backoff_ms': 100,
   'grpc.max_reconnect_backoff_ms': 100,
@@ -179,6 +179,58 @@ test('call over a silent path fails instead of hanging', async () => {
 });
 
 /**
+ * The timeout must be configurable, and disabled when set to `0` — otherwise
+ * there is no way back to the unpatched behavior.
+ */
+test('connection attempt timeout is configurable', async () => {
+  const server = await startSilentServer();
+
+  const disabled = createChannel(`127.0.0.1:${server.port}`, undefined, {
+    ...channelOptions,
+    'grpc.min_reconnect_backoff_ms': 0,
+  });
+
+  try {
+    disabled.getConnectivityState(true);
+
+    // With the timeout disabled, the channel is expected to stay in CONNECTING,
+    // i.e. behave as unpatched grpc-js does.
+    expect(await watchStateChange(disabled, connectivityState.IDLE, 1000)).toBe(
+      true,
+    );
+    expect(
+      await watchStateChange(
+        disabled,
+        connectivityState.CONNECTING,
+        connectTimeoutMs * 2,
+      ),
+    ).toBe(false);
+  } finally {
+    disabled.close();
+  }
+
+  // A custom value is honored: the attempt fails well before the 20s default.
+  const custom = createChannel(`127.0.0.1:${server.port}`, undefined, {
+    ...channelOptions,
+    'grpc.min_reconnect_backoff_ms': 1000,
+  });
+
+  try {
+    custom.getConnectivityState(true);
+
+    expect(await watchStateChange(custom, connectivityState.IDLE, 1000)).toBe(
+      true,
+    );
+    expect(
+      await watchStateChange(custom, connectivityState.CONNECTING, 5000),
+    ).toBe(true);
+  } finally {
+    custom.close();
+    await server.close();
+  }
+});
+
+/**
  * A timed out connection attempt must be torn down. Otherwise every retry
  * leaves behind an established socket that the client will never use, and a
  * channel reconnecting in a loop leaks a socket per attempt.
@@ -188,7 +240,7 @@ test('timed out connection attempts do not leak sockets', async () => {
 
   const channel = createChannel(`127.0.0.1:${server.port}`, undefined, {
     ...channelOptions,
-    'grpc-node.connect_timeout_ms': 500,
+    'grpc.min_reconnect_backoff_ms': 500,
   });
 
   try {

--- a/packages/nice-grpc/src/__tests__/connectTimeout.ts
+++ b/packages/nice-grpc/src/__tests__/connectTimeout.ts
@@ -86,9 +86,9 @@ function watchStateChange(
  * A connection attempt that completes at the TCP level but never receives the
  * server's HTTP/2 SETTINGS frame must not hang forever.
  *
- * The gRPC connection backoff spec requires a connection attempt to be given at
- * most `MIN_CONNECT_TIMEOUT` (20 seconds), after which it fails and the
- * subchannel goes to TRANSIENT_FAILURE, from where backoff retries it:
+ * The gRPC connection backoff spec bounds a connection attempt by a deadline, of
+ * at least `MIN_CONNECT_TIMEOUT` (20 seconds), after which the attempt fails and
+ * the subchannel goes to TRANSIENT_FAILURE, from where backoff retries it:
  * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
  *
  * grpc-js has no such timeout: `Http2SubchannelConnector.createSession` awaits

--- a/packages/nice-grpc/src/__tests__/connectTimeoutPatch.ts
+++ b/packages/nice-grpc/src/__tests__/connectTimeoutPatch.ts
@@ -1,0 +1,44 @@
+import {test, expect} from 'vitest';
+import {applyConnectTimeoutPatch} from '../client/connectTimeoutPatch';
+
+/**
+ * The patch is applied as a side effect of importing the library, so failing to
+ * apply it must never throw, and applying it twice must not stack wrappers.
+ */
+
+test('is applied to the current grpc-js', () => {
+  expect(applyConnectTimeoutPatch()).toBe(true);
+});
+
+test('is idempotent', () => {
+  applyConnectTimeoutPatch();
+
+  const transport = require('@grpc/grpc-js/build/src/transport');
+  const connect = transport.Http2SubchannelConnector.prototype.connect;
+  const tcpConnect = transport.Http2SubchannelConnector.prototype.tcpConnect;
+
+  expect(applyConnectTimeoutPatch()).toBe(true);
+
+  expect(transport.Http2SubchannelConnector.prototype.connect).toBe(connect);
+  expect(transport.Http2SubchannelConnector.prototype.tcpConnect).toBe(
+    tcpConnect,
+  );
+});
+
+test('does nothing when grpc-js internals are missing', () => {
+  const path = require.resolve('@grpc/grpc-js/build/src/transport');
+  const original = require.cache[path];
+
+  require.cache[path] = {
+    id: path,
+    filename: path,
+    loaded: true,
+    exports: {SomeRenamedConnector: class {}},
+  } as NodeJS.Module;
+
+  try {
+    expect(applyConnectTimeoutPatch()).toBe(false);
+  } finally {
+    require.cache[path] = original;
+  }
+});

--- a/packages/nice-grpc/src/__tests__/connectTimeoutPatch.ts
+++ b/packages/nice-grpc/src/__tests__/connectTimeoutPatch.ts
@@ -39,6 +39,10 @@ test('does nothing when grpc-js internals are missing', () => {
   try {
     expect(applyConnectTimeoutPatch()).toBe(false);
   } finally {
-    require.cache[path] = original;
+    if (original == null) {
+      delete require.cache[path];
+    } else {
+      require.cache[path] = original;
+    }
   }
 });

--- a/packages/nice-grpc/src/client/connectTimeoutPatch.ts
+++ b/packages/nice-grpc/src/client/connectTimeoutPatch.ts
@@ -4,7 +4,8 @@ import type {ChannelOptions} from '@grpc/grpc-js';
 /**
  * Default connection attempt timeout, in milliseconds.
  *
- * Matches `MIN_CONNECT_TIMEOUT` from the gRPC connection backoff spec:
+ * Matches the value of `MIN_CONNECT_TIMEOUT` — the shortest deadline a
+ * connection attempt may be given — from the gRPC connection backoff spec:
  * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
  */
 const defaultConnectTimeoutMs = 20_000;
@@ -39,10 +40,10 @@ const pendingSockets = new WeakMap<object, Set<Socket>>();
  * without a deadline hang indefinitely, and keepalive does not help because it
  * only applies to an established transport.
  *
- * The gRPC spec requires a connection attempt to be given at most
- * `MIN_CONNECT_TIMEOUT` (20 seconds), after which it fails and backoff retries
- * it. This patch adds that timeout, covering the whole attempt: TCP connect,
- * TLS handshake and waiting for SETTINGS.
+ * The gRPC spec has connection attempts bounded by a deadline, of at least
+ * `MIN_CONNECT_TIMEOUT` (20 seconds), after which the attempt fails and backoff
+ * retries it. This patch adds such a deadline, covering the whole attempt: TCP
+ * connect, TLS handshake and waiting for SETTINGS.
  *
  * Reported upstream: https://github.com/grpc/grpc-node/issues/2785
  *

--- a/packages/nice-grpc/src/client/connectTimeoutPatch.ts
+++ b/packages/nice-grpc/src/client/connectTimeoutPatch.ts
@@ -1,0 +1,163 @@
+import type {Socket} from 'net';
+import type {ChannelOptions} from '@grpc/grpc-js';
+
+/**
+ * Default connection attempt timeout, in milliseconds.
+ *
+ * Matches `MIN_CONNECT_TIMEOUT` from the gRPC connection backoff spec:
+ * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+ */
+const defaultConnectTimeoutMs = 20_000;
+
+/**
+ * Channel option that overrides the connection attempt timeout, in
+ * milliseconds. Set to `0` to disable the timeout.
+ */
+const connectTimeoutOption = 'grpc-node.connect_timeout_ms';
+
+type ConnectorPrototype = {
+  connect(
+    address: unknown,
+    secureConnector: unknown,
+    options: ChannelOptions,
+  ): Promise<{shutdown?(): void} | undefined>;
+  tcpConnect(address: unknown, options: ChannelOptions): Promise<Socket>;
+};
+
+const patchedFlag = Symbol.for('nice-grpc.connectTimeoutPatch');
+const pendingSockets = new WeakMap<object, Set<Socket>>();
+
+/**
+ * Enforces a timeout on connection attempts made by grpc-js.
+ *
+ * grpc-js has no timeout on establishing a connection: its connector awaits the
+ * server's HTTP/2 SETTINGS frame with no timer. If a peer accepts the TCP
+ * connection but never sends SETTINGS — a half-open network path, e.g. a broken
+ * middlebox flow — the connection attempt never settles. The subchannel stays in
+ * CONNECTING forever, and since backoff is only armed when an attempt *fails*,
+ * no retry is ever scheduled: the channel is dead until it is recreated. Calls
+ * without a deadline hang indefinitely, and keepalive does not help because it
+ * only applies to an established transport.
+ *
+ * The gRPC spec requires a connection attempt to be given at most
+ * `MIN_CONNECT_TIMEOUT` (20 seconds), after which it fails and backoff retries
+ * it. This patch adds that timeout, covering the whole attempt: TCP connect,
+ * TLS handshake and waiting for SETTINGS.
+ *
+ * Reported upstream: https://github.com/grpc/grpc-node/issues/2785
+ *
+ * The patch reaches into grpc-js internals, so it is applied defensively: if the
+ * internals are not shaped as expected (e.g. after an upgrade), it silently does
+ * nothing rather than breaking the library.
+ *
+ * @returns whether the patch was applied.
+ */
+export function applyConnectTimeoutPatch(): boolean {
+  let connectorPrototype: ConnectorPrototype;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const transport = require('@grpc/grpc-js/build/src/transport');
+    connectorPrototype = transport?.Http2SubchannelConnector?.prototype;
+  } catch {
+    return false;
+  }
+
+  if (
+    connectorPrototype == null ||
+    typeof connectorPrototype.connect !== 'function' ||
+    typeof connectorPrototype.tcpConnect !== 'function'
+  ) {
+    return false;
+  }
+
+  const flagged = connectorPrototype as {[patchedFlag]?: boolean};
+
+  if (flagged[patchedFlag]) {
+    return true;
+  }
+
+  const originalConnect = connectorPrototype.connect;
+  const originalTcpConnect = connectorPrototype.tcpConnect;
+
+  // Track the sockets opened by an attempt, so that a timed out attempt can be
+  // torn down instead of being left dangling.
+  connectorPrototype.tcpConnect = function tcpConnect(address, options) {
+    return originalTcpConnect.call(this, address, options).then(socket => {
+      let sockets = pendingSockets.get(this);
+
+      if (sockets == null) {
+        sockets = new Set();
+        pendingSockets.set(this, sockets);
+      }
+
+      sockets.add(socket);
+      socket.once('close', () => sockets!.delete(socket));
+
+      return socket;
+    });
+  };
+
+  connectorPrototype.connect = function connect(
+    address,
+    secureConnector,
+    options,
+  ) {
+    const timeoutMs =
+      options?.[connectTimeoutOption] ?? defaultConnectTimeoutMs;
+
+    const attempt = originalConnect.call(
+      this,
+      address,
+      secureConnector,
+      options,
+    );
+
+    if (!(timeoutMs > 0)) {
+      return attempt;
+    }
+
+    let timedOut = false;
+
+    // If the transport arrives after we gave up on it, shut it down: nothing is
+    // going to use it.
+    attempt.then(
+      transport => {
+        if (timedOut) {
+          transport?.shutdown?.();
+        }
+      },
+      () => {},
+    );
+
+    let timer: NodeJS.Timeout;
+
+    const timeout = new Promise<never>((resolve, reject) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+
+        const sockets = pendingSockets.get(this);
+
+        if (sockets != null) {
+          for (const socket of sockets) {
+            socket.destroy();
+          }
+
+          sockets.clear();
+        }
+
+        reject(new Error(`Connection attempt timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      timer.unref?.();
+    });
+
+    return Promise.race([attempt, timeout]).finally(() => {
+      clearTimeout(timer);
+    });
+  };
+
+  flagged[patchedFlag] = true;
+
+  return true;
+}

--- a/packages/nice-grpc/src/client/connectTimeoutPatch.ts
+++ b/packages/nice-grpc/src/client/connectTimeoutPatch.ts
@@ -13,8 +13,17 @@ const defaultConnectTimeoutMs = 20_000;
 /**
  * Channel option that overrides the connection attempt timeout, in
  * milliseconds. Set to `0` to disable the timeout.
+ *
+ * This is the channel argument that other gRPC implementations use for
+ * `MIN_CONNECT_TIMEOUT`, despite what its name suggests. C-core documents
+ * `GRPC_ARG_MIN_RECONNECT_BACKOFF_MS` as "the minimum time between subsequent
+ * connection attempts" referring to `MIN_CONNECT_TIMEOUT`, and parses it into
+ * the deadline it gives a connection attempt; the Objective-C wrapper maps its
+ * `connectMinTimeout` option onto it; grpc-go has the equivalent
+ * `MinConnectTimeout` in `ConnectParams`. grpc-js accepts the option but never
+ * reads it.
  */
-const connectTimeoutOption = 'grpc-node.connect_timeout_ms';
+const connectTimeoutOption = 'grpc.min_reconnect_backoff_ms';
 
 type ConnectorPrototype = {
   connect(

--- a/packages/nice-grpc/src/index.ts
+++ b/packages/nice-grpc/src/index.ts
@@ -1,3 +1,10 @@
+import {applyConnectTimeoutPatch} from './client/connectTimeoutPatch';
+
+// Works around the missing connection attempt timeout in grpc-js, which
+// otherwise leaves channels stuck in CONNECTING forever when a network path
+// accepts connections but never responds. See the module for details.
+applyConnectTimeoutPatch();
+
 export * from 'nice-grpc-common';
 
 export * from './server/Server';


### PR DESCRIPTION
## Problem

grpc-js has no timeout on establishing a connection. `Http2SubchannelConnector.createSession()` awaits the server's HTTP/2 SETTINGS frame with no timer, attaching only `remoteSettings`, `close` and `error` handlers.

If a peer accepts the TCP connection (and completes the TLS handshake) but never sends SETTINGS — a half-open network path, e.g. a flow broken by a middlebox — none of those fire. The connection attempt never settles, so:

- the subchannel stays in `CONNECTING` forever;
- backoff is only armed when an attempt *fails*, so no retry is ever scheduled;
- calls without a deadline hang indefinitely, and the channel is dead until it is recreated;
- keepalive does not help, since it only applies to an already-established transport.

This is also a spec deviation: per [`connection-backoff.md`](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md), `TryConnect` should be given a deadline of at least `MIN_CONNECT_TIMEOUT` (20 s) and fail into backoff when it expires. C-core and grpc-java do this.

This is not a contrived condition. It caused a production incident for us: a middlebox dropped established flows and, for a period, accepted new TCP connections into a black hole. Two pods out of eight happened to reconnect during that window and stayed dead for an hour, while the other six recovered normally.

Reported upstream as [grpc/grpc-node#2785](https://github.com/grpc/grpc-node/issues/2785) (also matches the symptoms reported there by another user). Reproduces on grpc-js `1.14.1` and `1.14.4`, and `master` has the same code.

## Fix

Wrap `Http2SubchannelConnector.prototype.connect` so that the whole attempt — TCP connect, TLS handshake and waiting for SETTINGS — is bounded by a timeout, defaulting to 20 s per the spec. On expiry the attempt rejects and the existing backoff machinery retries it. Configurable via the `grpc.min_reconnect_backoff_ms` channel option, `0` disables it. Misleading as that name is, it is the canonical argument for this: C-core parses `GRPC_ARG_MIN_RECONNECT_BACKOFF_MS` into the deadline it gives a connection attempt (documented as referring to `MIN_CONNECT_TIMEOUT`), the Objective-C wrapper maps its `connectMinTimeout` onto it, and grpc-go has the equivalent `ConnectParams.MinConnectTimeout`. grpc-js accepts the option but never reads it.

Two things worth calling out, both found the hard way:

- **`createSession()` is not patchable from the outside** — its `reject` is closed over inside the promise. `connect()` is the right seam, and it conveniently covers the full attempt.
- **A naive `Promise.race` leaks sockets.** The abandoned attempt keeps running, so a channel reconnecting in a loop accumulates one established socket per attempt (measured: 12 attempts → 12 open sockets). The patch tracks the sockets an attempt opened and destroys them on timeout, and shuts down a transport that arrives late.

Since the patch is applied as a side effect of importing the library, it is defensive: it `require`s grpc-js internals in a `try`/`catch`, verifies the connector methods are functions, and is idempotent (relevant when several copies of `nice-grpc` end up in a dependency tree). If the internals change shape after an upgrade, it does nothing instead of breaking the import.

## Tests

`src/__tests__/connectTimeout.ts` — against a TCP server that accepts connections and stays silent:

- the channel leaves `CONNECTING` instead of hanging;
- a call without a deadline fails with `UNAVAILABLE` instead of hanging;
- timed out attempts do not leak sockets.

`src/__tests__/connectTimeoutPatch.ts` — the patch applies, is idempotent, and degrades to a no-op when grpc-js internals are missing or renamed.

Verified in both directions: the timeout tests fail on unpatched grpc-js and pass with the patch. Full suite is green (88 tests).

Beyond the unit tests, the original failure was reproduced end to end — a client with a realistic workload (25 subscriptions plus unary loops) behind Envoy, with a proxy emulating the broken flow: reset the live connection, blackhole new ones, then heal. Before: the client never recovered, `connectivityState=CONNECTING`, calls hanging for 280+ seconds. After: it reconnects and resumes normally.

